### PR TITLE
Add hybrid v0.7 G2 metric training notebook

### DIFF
--- a/G2_ML/Complete_G2_Metric_Training_v0_7.ipynb
+++ b/G2_ML/Complete_G2_Metric_Training_v0_7.ipynb
@@ -728,7 +728,6 @@
    "id": "76017788",
    "metadata": {},
    "source": [
-    "\n",
     "## Usage\n",
     "\n",
     "Uncomment and execute the following cell after configuring runtime resources:\n",
@@ -736,7 +735,7 @@
     "```python\n",
     "# result = construct_k7_metric(epochs=800, batch_size=256)\n",
     "# save_json(result[\"topology\"], RESULTS_DIR / \"betti.json\")\n",
-    "# np.save(RESULTS_DIR / \"full_metric.npy\", result[\"metric\"])\n",
+    "# np.save(RESULTS_DIR / \"metric.npy\", result[\"metric\"])\n",
     "```\n"
    ]
   }


### PR DESCRIPTION
## Summary
- add the Complete_G2_Metric_Training_v0_7.ipynb Colab notebook describing the hybrid Joyce–PINN–Joyce construction strategy
- implement analytical solvers, neck PINN architecture, and training utilities tailored for the constrained neck interval
- include topology, holonomy, and Yukawa validation scaffolding plus an orchestration pipeline for the full K7 metric workflow

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912843f8da48320a9ab5a7bdeac2f52)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `G2_ML/Complete_G2_Metric_Training_v0_7.ipynb` implementing a Joyce–PINN hybrid pipeline with validation and orchestration to construct a K7 G2 metric.
> 
> - **New Notebook**: `G2_ML/Complete_G2_Metric_Training_v0_7.ipynb` (v0.7) with metadata, config, and reproducibility helpers.
> - **Core Components**:
>   - **Analytical Ends**: `JoyceAsymptoticSolver` generating asymptotic metric, three-form `phi`, curvature, and boundary bundles.
>   - **Building Blocks**: `CHNPBuilder` producing semi-Fano metrics and matching data (`seed_metric`, `target_volume_density`).
>   - **Neck PINN**: `NeckPINN` with Fourier features, SPD metric decoding, boundary interpolation, and `metric_tensor` composition.
>   - **Losses & Training**: Boundary match, torsion, volume preservation, smoothness; `train_neck_pinn` with AdamW and history tracking.
> - **Validation & Observables**:
>   - `TopologicalValidator` (Betti checks), `HolonomyChecker` (holonomy dimension estimate), `YukawaComputer` (coupling stats).
> - **Pipeline**:
>   - `construct_k7_metric` orchestrates solves, training, assembly, validations, and persists results to `G2_ML/output_v0_7/`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcca0d40087564763e6b418b8efac8d671d23600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->