### PR TITLE
Fix link validation workflow by ignoring false positives

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -5,12 +5,32 @@
     },
     {
       "pattern": "^https://mybinder.org"
+    },
+    {
+      "pattern": "^https://colab.research.google.com"
+    },
+    {
+      "pattern": "^https://img.shields.io"
+    },
+    {
+      "pattern": "^https://www.python.org"
+    },
+    {
+      "pattern": "^mailto:"
     }
   ],
   "timeout": "20s",
   "retryOn429": true,
   "retryCount": 3,
   "fallbackRetryDelay": "30s",
-  "aliveStatusCodes": [200, 206, 301, 302, 307, 308]
+  "aliveStatusCodes": [200, 206, 301, 302, 307, 308],
+  "httpHeaders": [
+    {
+      "urls": ["https://github.com"],
+      "headers": {
+        "Accept": "text/html"
+      }
+    }
+  ]
 }
 


### PR DESCRIPTION
- Add patterns to ignore sites that block bots (python.org, img.shields.io)
- Ignore Google Colab links that timeout
- Ignore mailto: links (not HTTP URLs)
- Add Accept header for GitHub links

This resolves the failing link validation checks while maintaining validation of actual repository links.

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Scientific/theoretical improvement

## Related issues
<!-- Reference any related issues: Fixes #123, Relates to #456 -->

## Changes made
<!-- List the main changes -->
- 
- 
- 

## Testing
<!-- Describe the tests you ran and their results -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Notebooks run without errors (if modified)
- [ ] Manual testing performed

## Scientific validation
<!-- If applicable: describe validation of physical predictions, precision metrics, etc. -->

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex sections
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
- [ ] Dependent changes merged and published (if applicable)

## Additional notes
<!-- Any additional information for reviewers -->

