### PR TITLE
fix: Correct broken GLOSSARY.md link in publications/README.md

### DIFF
--- a/publications/README.md
+++ b/publications/README.md
@@ -8,7 +8,7 @@ Geometric Information Field Theory: Deriving Standard Model parameters from E₈
 - **Main paper**: [gift_2_2_main.md](gift_2_2_main.md)
 - **All predictions**: [GIFT_v22_Observable_Reference.md](GIFT_v22_Observable_Reference.md)
 - **Reading guide**: [READING_GUIDE.md](READING_GUIDE.md)
-- **Terminology**: [GLOSSARY.md](GLOSSARY.md)
+- **Terminology**: [GLOSSARY.md](../docs/GLOSSARY.md)
 
 ## Key Results
 
@@ -42,7 +42,6 @@ publications/
 ├── gift_2_2_main.md                    # Main paper
 ├── summary.txt                         # Executive summary
 ├── READING_GUIDE.md                    # Navigation guide
-├── GLOSSARY.md                         # Terminology definitions
 ├── README.md                           # This file
 ├── GIFT_v22_Observable_Reference.md    # Complete observable list
 ├── GIFT_v22_Geometric_Justifications.md # Formula derivations


### PR DESCRIPTION
The GLOSSARY.md file was moved from publications/ to docs/ during the repository consolidation, but this link was not updated.

- Update link: GLOSSARY.md -> ../docs/GLOSSARY.md
- Remove outdated GLOSSARY.md from directory structure listing

This fixes the CI "Validate Markdown Links" workflow failures.

## Description
<!-- Provide a clear and concise description of your changes -->

## Type of change
<!-- Check all that apply -->
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Performance improvement
- [ ] Scientific/theoretical improvement

## Related issues
<!-- Reference any related issues: Fixes #123, Relates to #456 -->

## Changes made
<!-- List the main changes -->
- 
- 
- 

## Testing
<!-- Describe the tests you ran and their results -->
- [ ] Existing tests pass
- [ ] New tests added (if applicable)
- [ ] Notebooks run without errors (if modified)
- [ ] Manual testing performed

## Scientific validation
<!-- If applicable: describe validation of physical predictions, precision metrics, etc. -->

## Checklist
- [ ] Code follows the project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex sections
- [ ] Documentation updated (if needed)
- [ ] No new warnings introduced
- [ ] Dependent changes merged and published (if applicable)

## Additional notes
<!-- Any additional information for reviewers -->

