### PR TITLE
style: Editorial cleanup - replace em dashes with context-appropriate…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,8 @@ Relations involving irrational numbers (pi, phi) with certified rational parts:
 - 65/1952 = det(g) × κ_T (torsion correction)
 
 **New proof files**:
-- `IrrationalSector.lean` / `IrrationalSector.v` — θ₁₃, θ₂₃, α⁻¹ complete
-- `GoldenRatio.lean` / `GoldenRatio.v` — φ bounds, m_μ/m_e = 27^φ
+- `IrrationalSector.lean` / `IrrationalSector.v`: θ₁₃, θ₂₃, α⁻¹ complete
+- `GoldenRatio.lean` / `GoldenRatio.v`: φ bounds, m_μ/m_e = 27^φ
 - Updated `GaugeSector.lean` / `GaugeSector.v` with α⁻¹ complete (relation #36)
 
 #### Changed

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ See [CITATION.md](CITATION.md) for additional formats.
 
 ## License
 
-MIT License — see [LICENSE](LICENSE)
+MIT License. See [LICENSE](LICENSE)
 
 ---
 

--- a/publications/Lean/G2_Lean.md
+++ b/publications/Lean/G2_Lean.md
@@ -8,7 +8,7 @@
 
 Differential geometry theorems are notoriously difficult to formalize due to infinite-dimensional function spaces, nonlinear partial differential equations, and technical analytic estimates. We present a hybrid methodology combining physics-informed neural networks (PINNs) with formal verification in Lean 4, demonstrating feasibility through the construction of a compact 7-manifold with exceptional G₂ holonomy.
 
-Our pipeline transforms numerical solutions into formally verified existence proofs: (1) a PINN learns a candidate G₂ structure on the Kovalev K₇ manifold satisfying topological constraints; (2) interval arithmetic produces rigorous numerical certificates; (3) Lean 4 encodes these bounds and proves existence via Mathlib's Banach fixed-point theorem. Critically, our formalization uses **no axioms beyond Lean's core foundations** (`propext`, `Quot.sound`)—the existence proof is constructive and kernel-checked.
+Our pipeline transforms numerical solutions into formally verified existence proofs: (1) a PINN learns a candidate G₂ structure on the Kovalev K₇ manifold satisfying topological constraints; (2) interval arithmetic produces rigorous numerical certificates; (3) Lean 4 encodes these bounds and proves existence via Mathlib's Banach fixed-point theorem. Critically, our formalization uses **no axioms beyond Lean's core foundations** (`propext`, `Quot.sound`): the existence proof is constructive and kernel-checked.
 
 The complete implementation (training code, Lean proof, Colab notebook) runs in under 1 hour on free-tier cloud GPUs, enabling independent verification. While our approach simplifies certain geometric structures for tractability, it provides a concrete example of certifying machine learning-assisted mathematics using interactive theorem provers. To our knowledge, no prior work has formalized existence proofs for exceptional holonomy geometries in proof assistants.
 
@@ -452,8 +452,8 @@ Critical check:
 - `Quot.sound` (quotient soundness): Foundational axiom for quotient types, essential for constructing quotients in dependent type theory.
 
 These are **Lean core axioms**, not additional assumptions introduced by our proof. Notably absent:
-- `Classical.choice` (axiom of choice) — not needed
-- `Classical.em` (excluded middle) — proof is constructive
+- `Classical.choice` (axiom of choice): not needed
+- `Classical.em` (excluded middle): proof is constructive
 - Any domain-specific axioms (Joyce's theorem, etc.)
 
 Our proof is fully constructive within Lean's standard foundations.

--- a/publications/markdown/S1_mathematical_architecture_v23.md
+++ b/publications/markdown/S1_mathematical_architecture_v23.md
@@ -246,7 +246,7 @@ Matter field basis:
 
 $$\sin^2\theta_W = \frac{b_2}{b_3 + \dim(G_2)} = \frac{21}{77 + 14} = \frac{21}{91} = \frac{3}{13}$$
 
-**Status**: **PROVEN (Lean)** — `weinberg_angle_certified` in `GIFT.Relations.GaugeSector`
+**Status**: **PROVEN (Lean)**: `weinberg_angle_certified` in `GIFT.Relations.GaugeSector`
 
 ### 2.3.7 Torsion Magnitude from Cohomology
 
@@ -254,7 +254,7 @@ $$\kappa_T = \frac{1}{b_3 - \dim(G_2) - p_2} = \frac{1}{77 - 14 - 2} = \frac{1}{
 
 **Interpretation**: 61 = effective matter degrees of freedom for torsion
 
-**Status**: **PROVEN (Lean)** — `kappa_T_certified` in `GIFT.Certificate.MainTheorem`
+**Status**: **PROVEN (Lean)**: `kappa_T_certified` in `GIFT.Certificate.MainTheorem`
 
 ---
 
@@ -283,7 +283,7 @@ $$\tau = \frac{2^4 \times 7 \times 31}{3^4 \times 11}$$
 - 3⁴ = N_gen⁴ (generations)
 - 11 = rank(E₈) + N_gen = L₅ (Lucas)
 
-**Status**: **PROVEN (Lean)** — `tau_certified` in `GIFT.Certificate.MainTheorem`
+**Status**: **PROVEN (Lean)**: `tau_certified` in `GIFT.Certificate.MainTheorem`
 
 ---
 
@@ -330,7 +330,7 @@ $$\lambda_H = \frac{\sqrt{\dim(G_2) + N_{gen}}}{2^{Weyl}} = \frac{\sqrt{17}}{32}
 
 where 17 = 14 + 3 = dim(G₂) + N_gen.
 
-**Status**: **PROVEN (Lean)** — `lambda_H_num_certified` in `GIFT.Relations.HiggsSector`
+**Status**: **PROVEN (Lean)**: `lambda_H_num_certified` in `GIFT.Relations.HiggsSector`
 
 ---
 

--- a/publications/markdown/S2_K7_manifold_construction_v23.md
+++ b/publications/markdown/S2_K7_manifold_construction_v23.md
@@ -23,9 +23,9 @@ The Betti numbers b₂ = 21 and b₃ = 77 are fixed by the TCS construction (top
 | Property | Target | Achieved | Status |
 |----------|--------|----------|--------|
 | b₂(K₇) | 21 (TCS) | 21 | TOPOLOGICAL |
-| b₃(K₇) (topological) | 77 (TCS) | — | TOPOLOGICAL |
+| b₃(K₇) (topological) | 77 (TCS) | - | TOPOLOGICAL |
 | b₃(K₇) (spectral estimate) | 77 | 76 (Δ = 1 mode) | NUMERICAL |
-| det(g) (formula) | 65/32 | — | TOPOLOGICAL |
+| det(g) (formula) | 65/32 | - | TOPOLOGICAL |
 | det(g) (PINN) | 65/32 = 2.03125 | 2.0312490 ± 0.0001 | CERTIFIED |
 | ||T|| | < ε₀ | 0.00286 | CERTIFIED |
 | Joyce margin | > 1 | 35× | PROVEN |
@@ -286,12 +286,12 @@ Total: ~10,000 epochs (runs in 5-10 minutes on free cloud platforms like Colab).
 
 | Property | Target | Achieved | Status |
 |----------|--------|----------|--------|
-| det(g) (topological) | 65/32 | — | TOPOLOGICAL |
+| det(g) (topological) | 65/32 | - | TOPOLOGICAL |
 | det(g) (PINN) | 65/32 = 2.03125 | 2.0312490 ± 0.0001 | CERTIFIED |
 | ||T|| | < ε₀ | 0.00286 | CERTIFIED |
 | λ_min(g) | > 0 | 1.078 | CERTIFIED |
 | b₂ (spectral) | 21 | 21 | NUMERICAL |
-| b₃ (topological) | 77 (TCS) | — | TOPOLOGICAL |
+| b₃ (topological) | 77 (TCS) | - | TOPOLOGICAL |
 | b₃ (spectral) | 77 | 76 (Δ = 1 mode) | NUMERICAL |
 
 ### 6.2 Determinant Verification
@@ -423,7 +423,7 @@ The certificate has progressively eliminated axioms through partition of unity m
 | `joyce_lipschitz` | Lipschitz bound | Contraction property |
 | `fixed_point_torsion_zero` | Fixed point characterization | Joyce theorem consequence |
 
-The Banach fixed point theorem itself is **not axiomatized** — it comes from Mathlib's `ContractingWith.fixedPoint`.
+The Banach fixed point theorem itself is **not axiomatized**: it comes from Mathlib's `ContractingWith.fixedPoint`.
 
 ---
 
@@ -584,15 +584,15 @@ The (2, 21, 54) representation content under G₂ matches Standard Model fermion
 pip install giftpy
 ```
 See [gift-framework/core](https://github.com/gift-framework/core) for:
-- `gift_core/geometry/` — K3, ACyl CY3, TCS construction
-- `gift_core/g2/` — G₂ form, holonomy, torsion
-- `gift_core/harmonic/` — Hodge Laplacian, harmonic forms
-- `gift_core/nn/` — Physics-informed neural network
-- `gift_core/verification/` — Lean/Coq certificate export
+- `gift_core/geometry/`: K3, ACyl CY3, TCS construction
+- `gift_core/g2/`: G₂ form, holonomy, torsion
+- `gift_core/harmonic/`: Hodge Laplacian, harmonic forms
+- `gift_core/nn/`: Physics-informed neural network
+- `gift_core/verification/`: Lean/Coq certificate export
 
 **Historical notebooks** (archived in `legacy/G2_ML/`):
-- `G2_Lean/G2CertificateV2_3_Portable_trained.ipynb` — Development certificate
-- `variational_g2/` — Original PINN development
+- `G2_Lean/G2CertificateV2_3_Portable_trained.ipynb`: Development certificate
+- `variational_g2/`: Original PINN development
 
 ### 13.2 Usage
 
@@ -618,22 +618,22 @@ python -c "from gift_core import run_pipeline; r = run_pipeline(); print(r.certi
 This supplement demonstrates G₂ metric existence on K₇ through variational methods with formal verification:
 
 **Topological achievements** (exact, from TCS construction):
-- b₂ = 21, b₃ = 77 from Mayer-Vietoris — TOPOLOGICAL
-- det(g) = 65/32 from topological formula — TOPOLOGICAL
-- Local/global decomposition: 35 + 42 = 77 — TOPOLOGICAL
-- H* = 99 effective cohomological dimension — TOPOLOGICAL
+- b₂ = 21, b₃ = 77 from Mayer-Vietoris [TOPOLOGICAL]
+- det(g) = 65/32 from topological formula [TOPOLOGICAL]
+- Local/global decomposition: 35 + 42 = 77 [TOPOLOGICAL]
+- H* = 99 effective cohomological dimension [TOPOLOGICAL]
 
 **Numerical cross-checks** (PINN reconstruction):
-- det(g) = 2.0312490 ± 0.0001 matches topological 65/32 — CERTIFIED
-- ||T|| = 0.00286 with 35× margin below Joyce threshold — CERTIFIED
-- b₂ spectral: 21 (exact match) — NUMERICAL
-- b₃ spectral: 76 (Δ = 1 mode from topological 77) — NUMERICAL
+- det(g) = 2.0312490 ± 0.0001 matches topological 65/32 [CERTIFIED]
+- ||T|| = 0.00286 with 35× margin below Joyce threshold [CERTIFIED]
+- b₂ spectral: 21 (exact match) [NUMERICAL]
+- b₃ spectral: 76 (Δ = 1 mode from topological 77) [NUMERICAL]
 
 **Formal certification** (Lean 4.14.0 + Mathlib 4.14.0):
-- Banach fixed point theorem from Mathlib (no axioms for FP) — PROVEN
-- All numerical bounds machine-checked — PROVEN
-- SORRY reduction: v2.0(4) → v2.1(3) → v2.3(0 core SORRY) — PROVEN
-- Existence of torsion-free G₂ structure via ContractingWith.fixedPoint — PROVEN
+- Banach fixed point theorem from Mathlib (no axioms for FP) [PROVEN]
+- All numerical bounds machine-checked [PROVEN]
+- SORRY reduction: v2.0(4) → v2.1(3) → v2.3(0 core SORRY) [PROVEN]
+- Existence of torsion-free G₂ structure via ContractingWith.fixedPoint [PROVEN]
 
 **GIFT paradigm validation**:
 The construction validates the zero continuous adjustable parameter paradigm. All targets (det(g) = 65/32, κ_T = 1/61, b₂ = 21, b₃ = 77) derive from fixed mathematical structure. The TCS construction fixes these values exactly; the neural network provides independent numerical cross-checks rather than discovering the values through unconstrained optimization.

--- a/publications/markdown/S4_complete_derivations_v23.md
+++ b/publications/markdown/S4_complete_derivations_v23.md
@@ -238,7 +238,7 @@ $$\det(g) = \frac{H^* - b_2 - 13}{32} = \frac{99 - 21 - 13}{32} = \frac{65}{32}$
 |----------|-------|--------|
 | Topological target | 65/32 = 2.03125 | TOPOLOGICAL |
 | PINN result | 2.0312490 ± 0.0001 | CERTIFIED |
-| Deviation | 0.00005% | — |
+| Deviation | 0.00005% | - |
 
 **Lean 4 certification** (see [gift-framework/core](https://github.com/gift-framework/core) or `legacy/G2_ML/G2_Lean/G2Certificate.lean`):
 
@@ -688,7 +688,7 @@ $$\Omega_{DM} = \frac{b_2(K_7)}{b_3(K_7)} = \frac{21}{77} = 0.2727$$
 **Formula**:
 $$r = \frac{p_2^4}{b_2(K_7) \cdot b_3(K_7)} = \frac{16}{1617} = 0.0099$$
 
-**Experimental comparison**: r < 0.036 (95% CL) — consistent
+**Experimental comparison**: r < 0.036 (95% CL) [consistent]
 
 **Status**: THEORETICAL (testable by CMB-S4)
 

--- a/publications/markdown/S5_experimental_validation_v23.md
+++ b/publications/markdown/S5_experimental_validation_v23.md
@@ -336,14 +336,14 @@ $$\det(g) = p_2 + \frac{1}{b_2 + \dim(G_2) - N_{gen}} = 2 + \frac{1}{32} = \frac
 **Prediction**: Ω_DE = ln(2) × 98/99 = 0.686146
 **Tolerance**: ± 1%
 **Falsification criterion**: If Ω_DE is measured outside [0.679, 0.693] with uncertainty < 0.003, framework is disfavored.
-**Current status**: Planck 2020: 0.6847 ± 0.0073 — CONSISTENT
+**Current status**: Planck 2020: 0.6847 ± 0.0073 [CONSISTENT]
 
 ### 15.2 Strong Coupling
 
 **Prediction**: α_s(M_Z) = √2/12 = 0.117851...
 **Tolerance**: ± 0.002
 **Falsification criterion**: If α_s(M_Z) is measured outside [0.116, 0.120] with uncertainty < 0.0005, framework prediction needs revision.
-**Current status**: PDG 2024: 0.1179 ± 0.0009 — CONSISTENT
+**Current status**: PDG 2024: 0.1179 ± 0.0009 [CONSISTENT]
 
 ### 15.3 Neutrino Mixing Angles
 
@@ -357,7 +357,7 @@ $$\det(g) = p_2 + \frac{1}{b_2 + \dim(G_2) - N_{gen}} = 2 + \frac{1}{32} = \frac
 
 **Prediction**: λ_H = √17/32 = 0.12891
 **Tolerance**: ± 0.005
-**Current status**: LHC: 0.129 ± 0.003 — CONSISTENT
+**Current status**: LHC: 0.129 ± 0.003 [CONSISTENT]
 
 ---
 

--- a/publications/markdown/gift_2_3_main.md
+++ b/publications/markdown/gift_2_3_main.md
@@ -22,7 +22,7 @@ Whether this mathematical structure reflects fundamental reality or constitutes 
 
 Throughout this paper, we use the following classifications:
 
-- **PROVEN (Lean)**: Formally verified by Lean 4 kernel with Mathlib—machine-checked proofs using only standard axioms (propext, Quot.sound), zero domain-specific axioms, zero sorry
+- **PROVEN (Lean)**: Formally verified by Lean 4 kernel with Mathlib, machine-checked proofs using only standard axioms (propext, Quot.sound), zero domain-specific axioms, zero sorry
 - **PROVEN**: Exact topological identity with rigorous mathematical proof (see Supplement S4)
 - **TOPOLOGICAL**: Direct consequence of manifold structure without empirical input
 - **CERTIFIED**: Numerical result verified via interval arithmetic with rigorous bounds
@@ -526,7 +526,7 @@ $$\tau = \frac{2^4 \times 7 \times 31}{3^4 \times 11} = \frac{p_2^4 \times \dim(
 
 **Significance**: τ is rational, not transcendental. This indicates the framework encodes exact discrete ratios rather than continuous quantities requiring infinite precision.
 
-**Status**: **PROVEN (Lean)** — `tau_certified` in `GIFT.Certificate.MainTheorem`
+**Status**: **PROVEN (Lean)**: `tau_certified` in `GIFT.Certificate.MainTheorem`
 
 **Mathematical resonances**:
 - τ² ≈ 15.18 ≈ 3π²/2 (within 2.8%)
@@ -631,7 +631,7 @@ $$\sin^2\theta_W = \frac{b_2(K_7)}{b_3(K_7) + \dim(G_2)} = \frac{21}{77 + 14} = 
 
 **Numerical value**: 3/13 = 0.230769...
 
-**Status**: **PROVEN (Lean)** — `weinberg_angle_certified` in `GIFT.Relations.GaugeSector`
+**Status**: **PROVEN (Lean)**: `weinberg_angle_certified` in `GIFT.Relations.GaugeSector`
 
 | Observable | Experimental | GIFT | Deviation |
 |------------|--------------|------|-----------|
@@ -677,7 +677,7 @@ $$\sin^2\theta_W = \frac{b_2(K_7)}{b_3(K_7) + \dim(G_2)} = \frac{21}{77 + 14} = 
 
 **Derivation**: Additive topological formula where dim(G₂) = 14 is the G₂ Lie algebra dimension (proof in Supplement S4)
 
-**Status**: **PROVEN (Lean)** — `delta_CP_certified` in `GIFT.Relations.NeutrinoSector`
+**Status**: **PROVEN (Lean)**: `delta_CP_certified` in `GIFT.Relations.NeutrinoSector`
 
 | Observable | Experimental | GIFT | Deviation |
 |------------|--------------|------|-----------|
@@ -689,7 +689,7 @@ $$\sin^2\theta_W = \frac{b_2(K_7)}{b_3(K_7) + \dim(G_2)} = \frac{21}{77 + 14} = 
 
 **Formula**: Q = dim(G₂)/b₂(K₇) = 14/21 = 2/3
 
-**Status**: **PROVEN (Lean)** — `koide_certified` in `GIFT.Relations.LeptonSector`
+**Status**: **PROVEN (Lean)**: `koide_certified` in `GIFT.Relations.LeptonSector`
 
 | Observable | Experimental | GIFT | Deviation |
 |------------|--------------|------|-----------|
@@ -721,7 +721,7 @@ $$\sin^2\theta_W = \frac{b_2(K_7)}{b_3(K_7) + \dim(G_2)} = \frac{21}{77 + 14} = 
 
 **Formula**: m_τ/m_e = dim(K₇) + 10 × dim(E₈) + 10 × H* = 7 + 2480 + 990 = 3477
 
-**Status**: **PROVEN (Lean)** — `m_tau_m_e_certified` in `GIFT.Relations.LeptonSector`
+**Status**: **PROVEN (Lean)**: `m_tau_m_e_certified` in `GIFT.Relations.LeptonSector`
 
 | Observable | Experimental | GIFT | Deviation |
 |------------|--------------|------|-----------|
@@ -733,7 +733,7 @@ $$\sin^2\theta_W = \frac{b_2(K_7)}{b_3(K_7) + \dim(G_2)} = \frac{21}{77 + 14} = 
 
 **Formula**: m_s/m_d = p₂² × Weyl_factor = 4 × 5 = 20
 
-**Status**: **PROVEN (Lean)** — `m_s_m_d_certified` in `GIFT.Relations.QuarkSector`
+**Status**: **PROVEN (Lean)**: `m_s_m_d_certified` in `GIFT.Relations.QuarkSector`
 
 | Observable | Experimental | GIFT | Deviation |
 |------------|--------------|------|-----------|
@@ -794,7 +794,7 @@ $$\lambda_H = \frac{\sqrt{\dim(G_2) + N_{gen}}}{2^{Weyl}} = \frac{\sqrt{14 + 3}}
 
 **Numerical value**: λ_H = √17/32 = 0.128906...
 
-**Status**: **PROVEN (Lean)** — `lambda_H_num_certified` in `GIFT.Relations.HiggsSector`
+**Status**: **PROVEN (Lean)**: `lambda_H_num_certified` in `GIFT.Relations.HiggsSector`
 
 | Observable | Experimental | GIFT | Deviation |
 |------------|--------------|------|-----------|

--- a/publications/references/GIFT_v23_Geometric_Justifications.md
+++ b/publications/references/GIFT_v23_Geometric_Justifications.md
@@ -511,7 +511,7 @@ The metric determinant measures the "volume element" of the internal manifold. I
 |----------|-------|--------|
 | Topological target | 65/32 = 2.03125 | TOPOLOGICAL |
 | PINN reconstruction | 2.0312490 ± 0.0001 | CERTIFIED |
-| Deviation | 0.00005% | — |
+| Deviation | 0.00005% | - |
 
 **Lean 4 certification**: The PINN solution satisfies Joyce's perturbation theorem with 20× safety margin (||T|| = 0.00140 < ε₀ = 0.0288). See Supplement S2 and [gift-framework/core](https://github.com/gift-framework/core).
 

--- a/publications/references/GIFT_v23_Observable_Reference.md
+++ b/publications/references/GIFT_v23_Observable_Reference.md
@@ -183,7 +183,7 @@ Geometric interpretation:
 
 ### 2.2 Weak Mixing Angle sin²θ_W
 
-**Status**: **PROVEN (Lean)** — `weinberg_angle_certified` in `GIFT.Relations.GaugeSector`
+**Status**: **PROVEN (Lean)**: `weinberg_angle_certified` in `GIFT.Relations.GaugeSector`
 
 **Formula**:
 ```
@@ -329,7 +329,7 @@ where:
 
 ### 3.4 CP Violation Phase δ_CP
 
-**Status**: **PROVEN (Lean)** — `delta_CP_certified` in `GIFT.Relations.NeutrinoSector`
+**Status**: **PROVEN (Lean)**: `delta_CP_certified` in `GIFT.Relations.NeutrinoSector`
 
 **Formula**:
 ```
@@ -356,7 +356,7 @@ where:
 
 ### 4.1 Koide Parameter Q
 
-**Status**: **PROVEN (Lean)** — `koide_certified` in `GIFT.Relations.LeptonSector`
+**Status**: **PROVEN (Lean)**: `koide_certified` in `GIFT.Relations.LeptonSector`
 
 **Formula**:
 ```
@@ -409,7 +409,7 @@ where φ = (1+√5)/2 is the golden ratio.
 
 ### 4.3 Tau-Electron Mass Ratio
 
-**Status**: **PROVEN (Lean)** — `m_tau_m_e_certified` in `GIFT.Relations.LeptonSector`
+**Status**: **PROVEN (Lean)**: `m_tau_m_e_certified` in `GIFT.Relations.LeptonSector`
 
 **Formula**:
 ```
@@ -436,7 +436,7 @@ m_τ/m_e = dim(K₇) + 10·dim(E₈) + 10·H*
 
 ### 5.1 Strange-Down Ratio m_s/m_d
 
-**Status**: **PROVEN (Lean)** — `m_s_m_d_certified` in `GIFT.Relations.QuarkSector`
+**Status**: **PROVEN (Lean)**: `m_s_m_d_certified` in `GIFT.Relations.QuarkSector`
 
 **Formula**:
 ```
@@ -603,7 +603,7 @@ M_Z = M_W / cos(θ_W) = 91.20 GeV
 
 ### 7.4 Higgs Self-Coupling λ_H
 
-**Status**: **PROVEN (Lean)** — `lambda_H_num_certified` in `GIFT.Relations.HiggsSector`
+**Status**: **PROVEN (Lean)**: `lambda_H_num_certified` in `GIFT.Relations.HiggsSector`
 
 **Formula**:
 ```
@@ -848,9 +848,9 @@ Framework constants systematically encode Fibonacci (F_n) and Lucas (L_n) number
 | Status | Count | Mean Deviation | Description |
 |--------|-------|----------------|-------------|
 | **PROVEN (Lean + Coq)** | **39** | 0.12% | Dual-verified (Lean 4 + Coq 8.18, zero domain axioms) |
-| **TOPOLOGICAL** | **0** | — | Promoted to PROVEN |
-| DERIVED | 0 | — | Promoted to PROVEN |
-| THEORETICAL | 0 | — | All observables now PROVEN |
+| **TOPOLOGICAL** | **0** | - | Promoted to PROVEN |
+| DERIVED | 0 | - | Promoted to PROVEN |
+| THEORETICAL | 0 | - | All observables now PROVEN |
 
 ### 11.4 Lean 4 + Coq Verified Relations (Complete List)
 


### PR DESCRIPTION
… punctuation

Systematic replacement of em dashes (—) throughout documentation:

Tableaux (valeurs nulles):
- "| — |" → "| - |"

Statuts PROVEN:
- "**Status**: **PROVEN** — `theorem`" → "**Status**: **PROVEN**: `theorem`"

Listes et explications:
- "axiom — not needed" → "axiom: not needed"
- "`module/` — description" → "`module/`: description"
- "result — TOPOLOGICAL" → "result [TOPOLOGICAL]"
- "MIT License — see" → "MIT License. See"

Files: 10 markdown documents across publications/, docs/, and root

🤖 Generated with [Claude Code](https://claude.ai/code)