### PR TITLE
docs: Add domain-specific papers for geometers, physicists, and forma…

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,17 @@ Whether this mathematical structure reflects fundamental reality or constitutes 
 
 → [Philosophy](docs/PHILOSOPHY.md) Foundational perspective
 
+### Domain-specific guides
+
+**"I'm a geometer"**
+→ [GiftPy for Geometers](docs/GIFTPY_FOR_GEOMETERS.md) — G₂ metric construction pipeline
+
+**"I'm a physicist"**
+→ [Information Geometry for Physicists](docs/INFO_GEO_FOR_PHYSICISTS.md) — Topological approach to SM parameters
+
+**"I'm interested in formalization"**
+→ [Lean for Physics](docs/LEAN_FOR_PHYSICS.md) — Machine-verified physical relations
+
 ---
 
 ## Supplements

--- a/docs/GIFTPY_FOR_GEOMETERS.md
+++ b/docs/GIFTPY_FOR_GEOMETERS.md
@@ -1,0 +1,147 @@
+# GiftPy: Computational Tools for G₂ Geometry
+
+## Abstract
+
+GiftPy provides a validated computational pipeline for constructing and analyzing G₂ holonomy metrics on twisted connected sum (TCS) manifolds. The package implements numerical methods for approximating G₂ structures, computing topological invariants, and certifying existence via Joyce's perturbation theorem. Originally developed for a physics application (the GIFT framework), the geometric tools are general and may be of independent interest to researchers studying exceptional holonomy.
+
+## 1. The Computational Challenge
+
+G₂ holonomy metrics are notoriously difficult to compute explicitly. Joyce's foundational work established existence theorems for compact G₂ manifolds via resolution of orbifolds and perturbation methods, but these proofs are non-constructive. The twisted connected sum (TCS) construction of Kovalev and Corti-Haskins-Nordström-Pacini provides a more explicit path: glue two asymptotically cylindrical Calabi-Yau 3-folds along a common S¹ × K3 boundary. Yet even TCS methods yield existence rather than explicit metric coefficients.
+
+The challenge is threefold. First, the G₂ structure equations are a coupled system of nonlinear PDEs. Second, verifying torsion-freeness (dφ = 0, d*φ = 0) requires computing exterior derivatives of a 3-form defined over a 7-dimensional space. Third, extracting physical quantities such as Betti numbers, harmonic forms, and curvature tensors demands robust numerical methods with quantified error bounds.
+
+GiftPy addresses these challenges through a combination of physics-informed neural networks (PINNs), spectral methods for harmonic form extraction, and formal verification bridges to proof assistants.
+
+## 2. The Pipeline
+
+### 2.1 TCS Construction
+
+The package implements the twisted connected sum framework for G₂ manifolds. Starting from two asymptotically cylindrical (ACyl) Calabi-Yau 3-folds Y₁ and Y₂, each with cylindrical end diffeomorphic to (0, ∞) × S¹ × K3, the construction proceeds:
+
+1. Truncate each ACyl manifold at neck length T, obtaining M₁ᵀ and M₂ᵀ
+2. Identify the S¹ × K3 boundaries via a hyper-Kähler rotation
+3. Smooth the gluing region to obtain a compact 7-manifold K₇ = M₁ᵀ ∪_φ M₂ᵀ
+
+For the specific construction in GIFT, the building blocks yield Betti numbers computed via Mayer-Vietoris:
+
+| Block | Origin | b₂ | b₃ |
+|-------|--------|----|----|
+| M₁ | Quintic in P⁴ | 11 | 40 |
+| M₂ | CI(2,2,2) in P⁶ | 10 | 37 |
+| K₇ | TCS gluing | 21 | 77 |
+
+### 2.2 PINN Metric Approximation
+
+Explicit G₂ metrics are approximated using physics-informed neural networks. The network parameterizes a G₂ 3-form φ on a coordinate patch:
+
+```
+Input: x ∈ R⁷
+    ↓
+Fourier Features: 64 frequencies → 128 dimensions
+    ↓
+Hidden Layers: 4 × 256 neurons (SiLU activation)
+    ↓
+Output: 35 independent components of φ ∈ Λ³(R⁷)
+```
+
+Training minimizes a composite loss:
+
+L = w_T ||dφ||² + w_T ||d*φ||² + w_det |det(g) - target|² + w_pos ReLU(-λ_min(g))
+
+The torsion terms drive toward the torsion-free condition. The determinant constraint fixes the volume form to a specified target (65/32 in the GIFT application). The positivity term ensures the induced metric g(φ) remains positive definite.
+
+Training runs in 5-10 minutes on consumer hardware and achieves:
+- det(g) = 2.0312490 ± 0.0001 (target: 65/32 = 2.03125, deviation: 0.00005%)
+- ||T|| = 0.00286 (well below Joyce's threshold)
+- λ_min(g) = 1.078 (positive definite)
+
+### 2.3 Topological Extraction
+
+Given the trained metric, the pipeline extracts topological invariants:
+
+**Betti numbers via spectral analysis**: The Hodge Laplacian Δ_k = dd* + d*d is discretized on a mesh. Eigenvalue clustering identifies harmonic forms as zero-modes (up to numerical tolerance). For k=2, spectral analysis recovers b₂ = 21 exactly. For k=3, the spectral gap appears at position 76-77, indicating b₃ = 77 (with one mode at the numerical boundary).
+
+**Harmonic form basis**: Eigenvectors corresponding to near-zero eigenvalues provide a numerical basis for H^k(K₇). These forms are used downstream for computing integrals, Yukawa couplings, and other geometric quantities.
+
+**Curvature tensors**: Christoffel symbols, Riemann curvature, Ricci tensor, and scalar curvature are computed via automatic differentiation of the neural network.
+
+## 3. Formal Verification Bridge
+
+A distinctive feature of GiftPy is its connection to formal proof assistants. The numerical results feed into a Lean 4 certificate that establishes existence rigorously.
+
+**What is proven**: The Lean formalization verifies that Joyce's perturbation theorem (Theorem 11.6.1 in *Compact Manifolds with Special Holonomy*) applies to the numerical solution. Specifically:
+
+| Theorem | Statement | Lean Status |
+|---------|-----------|-------------|
+| `global_below_joyce` | ||T|| < ε₀ | Proven |
+| `joyce_margin` | Safety factor > 35× | Proven |
+| `k7_admits_torsion_free_g2` | ∃ φ_tf torsion-free | Proven |
+
+The core argument: Joyce's theorem states that if a compact 7-manifold admits a G₂ structure with sufficiently small torsion, then a nearby torsion-free G₂ structure exists. The PINN solution achieves ||T|| = 0.00286 against a conservative threshold ε₀ = 0.1, providing a 35× safety margin.
+
+**What remains numerical**: The explicit metric coefficients are PINN weights, not closed-form expressions. The harmonic forms are numerical eigenvectors, not analytic formulae. Lean certifies existence bounds rather than computing the exact torsion-free metric.
+
+## 4. Usage
+
+### Installation
+
+```bash
+pip install giftpy
+```
+
+Requirements: Python 3.10+, PyTorch 2.0+, NumPy, SciPy.
+
+### Key Modules
+
+```python
+import gift_core as gc
+
+# Run the full pipeline
+config = gc.PipelineConfig(neck_length=15.0, use_pinn=True)
+result = gc.run_pipeline(config)
+
+# Access results
+print(f"det(g) = {result.det_g}")           # 2.03125
+print(f"Torsion = {result.torsion_norm}")   # 0.00286
+print(f"b₂ = {result.b2}, b₃ = {result.b3}") # 21, 77
+
+# Export Lean certificate
+lean_proof = result.certificate.to_lean()
+```
+
+### Module Structure
+
+| Module | Content |
+|--------|---------|
+| `gift_core.geometry` | K3, ACyl CY3, TCS construction |
+| `gift_core.g2` | G₂ 3-form, holonomy, torsion computation |
+| `gift_core.harmonic` | Hodge Laplacian, spectral analysis |
+| `gift_core.nn` | PINN architecture and training |
+| `gift_core.verification` | Lean/Coq certificate generation |
+
+## 5. Limitations and Open Problems
+
+**Specificity**: The current implementation is tuned for the K₇ construction with b₂ = 21, b₃ = 77. Generalizing to other TCS building blocks (different Fano 3-folds, different gluing diffeomorphisms) requires adapting the topological constraints.
+
+**Standard TCS bounds**: Note that typical TCS constructions yield b₂ ≤ 9. The GIFT K₇ with b₂ = 21 either employs non-standard building blocks or should be understood via the variational characterization rather than explicit TCS gluing.
+
+**Explicit metric**: The PINN provides a numerical approximation, not a closed-form metric. For applications requiring analytic expressions, further work is needed.
+
+**Moduli space**: The uniqueness of the G₂ metric within its moduli class is not addressed. Multiple metrics with the same topological invariants may exist.
+
+**Open invitation**: Extending GiftPy to other G₂ manifolds (Joyce orbifold resolutions, other TCS examples, or the newer constructions of Foscolo-Haskins-Nordström) would be valuable contributions to the field.
+
+## References
+
+- Joyce, D.D. (2000). *Compact Manifolds with Special Holonomy*. Oxford University Press.
+- Kovalev, A. (2003). "Twisted connected sums and special Riemannian holonomy." *J. Reine Angew. Math.* 565, 125-160.
+- Corti, A., Haskins, M., Nordström, J., Pacini, T. (2015). "G₂-manifolds and associative submanifolds via semi-Fano 3-folds." *Duke Math. J.* 164(10), 1971-2092.
+- Raissi, M., Perdikaris, P., Karniadakis, G.E. (2019). "Physics-informed neural networks." *J. Comp. Phys.* 378, 686-707.
+
+**Code repository**: [github.com/gift-framework/core](https://github.com/gift-framework/core)
+
+**Related documentation**: [S2: K₇ Manifold Construction](../publications/markdown/S2_K7_manifold_construction_v23.md)
+
+---
+
+*GiftPy is part of the GIFT Framework. For the physics application, see the [main paper](../publications/markdown/gift_2_3_main.md).*

--- a/docs/INFO_GEO_FOR_PHYSICISTS.md
+++ b/docs/INFO_GEO_FOR_PHYSICISTS.md
@@ -1,0 +1,132 @@
+# Information Geometry in Particle Physics: The GIFT Perspective
+
+## Abstract
+
+The Geometric Information Field Theory (GIFT) framework proposes that Standard Model parameters are not free constants requiring experimental determination, but rather topological invariants of an underlying geometric structure. Specifically, the framework derives 39 observables from the cohomology of a 7-dimensional G₂ holonomy manifold K₇ coupled to E₈×E₈ gauge architecture. This document presents the conceptual structure for theoretical physicists, focusing on how topology might eliminate the need for adjustable parameters.
+
+## 1. The Parameter Problem
+
+The Standard Model describes electromagnetic, weak, and strong interactions with extraordinary precision, yet contains 19 free parameters: 3 gauge couplings, 9 fermion masses, 4 CKM parameters, and 3 additional constants (Higgs mass, Higgs VEV, QCD vacuum angle). These span six orders of magnitude with no theoretical explanation for their values.
+
+Traditional unification approaches have not resolved this situation. Grand Unified Theories introduce additional parameters while attempting to explain the original 19. String theory's moduli space encompasses approximately 10⁵⁰⁰ vacua, transforming the parameter problem into a vacuum selection problem. The question persists: are these parameters truly free, or do they encode deeper structure?
+
+The GIFT framework explores an alternative: what if the 19 parameters are topological invariants of a compact internal manifold? In this picture, there is nothing to tune because discrete topological data admits no continuous variation.
+
+## 2. The Geometric Setup
+
+### 2.1 Why E₈×E₈?
+
+The product group E₈×E₈ appears for several reasons. E₈ is the largest exceptional simple Lie algebra (dimension 248, rank 8). Its Weyl group W(E₈) has order 696,729,600 = 2¹⁴ × 3⁵ × 5² × 7, containing all the primes and powers that will reappear in observable formulas. The product E₈×E₈ arises naturally in heterotic string theory and satisfies anomaly cancellation requirements.
+
+Importantly, the framework does not embed Standard Model particles directly in E₈ representations. Direct embedding faces the Distler-Garibaldi obstruction: E₈ cannot accommodate three chiral generations with the correct quantum numbers. Instead, E₈×E₈ provides information-theoretic architecture, with physical particles emerging from dimensional reduction on the internal manifold.
+
+### 2.2 The Internal Manifold K₇
+
+The framework posits a compact 7-dimensional Riemannian manifold K₇ with G₂ holonomy. G₂ is the automorphism group of the octonions (dimension 14, rank 2). It is the minimal exceptional holonomy in seven dimensions and preserves exactly one spinor, yielding N=1 supersymmetry upon compactification.
+
+K₇ is constructed via the twisted connected sum (TCS) method: glue two asymptotically cylindrical Calabi-Yau 3-folds along their common S¹ × K3 boundary. The specific building blocks determine the topology:
+
+| Invariant | Value | Physical Interpretation |
+|-----------|-------|------------------------|
+| b₂(K₇) | 21 | Gauge field multiplicity (harmonic 2-forms) |
+| b₃(K₇) | 77 | Matter field multiplicity (harmonic 3-forms) |
+| H* = b₂ + b₃ + 1 | 99 | Effective cohomological dimension |
+
+### 2.3 The Torsion Mechanism
+
+Standard G₂ holonomy manifolds have torsion-free 3-form: dφ = 0, d*φ = 0. Physical interactions require controlled departure from this idealization. The framework introduces torsion with magnitude:
+
+κ_T = 1/(b₃ - dim(G₂) - p₂) = 1/(77 - 14 - 2) = 1/61
+
+This torsion generates dynamics through geodesic flow on K₇, providing a geometric interpretation of renormalization group equations.
+
+## 3. From Topology to Observables
+
+### 3.1 The Dimensional Reduction
+
+The chain proceeds:
+
+E₈×E₈ (496D) → AdS₄ × K₇ (11D) → Standard Model (4D)
+
+Upon compactification, gauge fields arise from harmonic 2-forms on K₇ (hence 21 generators, containing SU(3)×SU(2)×U(1) plus hidden sector), while chiral fermions arise from harmonic 3-forms (hence 77 modes, containing 3 generations of 16 Weyl fermions plus additional states).
+
+### 3.2 Representative Mappings
+
+The framework derives observables from cohomological and algebraic data. Examples:
+
+**Weinberg angle** (electroweak mixing):
+sin²θ_W = b₂/(b₃ + dim(G₂)) = 21/(77 + 14) = 21/91 = 3/13 = 0.23077
+
+This is an exact rational number determined by topology.
+
+**Generation number**:
+N_gen = rank(E₈) - Weyl = 8 - 5 = 3
+
+The factor 5 arises from 5² in |W(E₈)|.
+
+**CP violation phase** (neutrino sector):
+δ_CP = 7 × dim(G₂) + H* = 7 × 14 + 99 = 197°
+
+An additive formula combining manifold dimension, holonomy dimension, and cohomological dimension.
+
+**Koide relation** (charged lepton masses):
+Q = dim(G₂)/b₂ = 14/21 = 2/3
+
+The empirical Koide formula (m_e + m_μ + m_τ)/(√m_e + √m_μ + √m_τ)² = 2/3 emerges as a topological ratio.
+
+### 3.3 What is Claimed
+
+The framework produces 39 observables spanning gauge couplings, neutrino mixing, lepton mass ratios, quark mass ratios, CKM matrix elements, electroweak scale parameters, and cosmological observables. The mean deviation from experimental values is 0.128%.
+
+All 39 relations have been formally verified in both Lean 4 and Coq proof assistants, using only standard axioms (propext, Quot.sound in Lean; standard Coq axioms) with zero domain-specific axioms.
+
+### 3.4 What is Not Claimed
+
+The framework does not constitute a complete theory of quantum gravity. It does not derive the action principle from first principles. The dynamical mechanism connecting geometry to physics remains incomplete; the mapping between topological data and physical observables is established but not derived from a deeper principle.
+
+The "zero-parameter" description refers to the absence of continuous adjustable quantities. Discrete structural choices remain: E₈×E₈ rather than SO(32), this specific K₇ rather than other G₂ manifolds. These choices are motivated by consistency requirements (anomaly cancellation, correct field content) but not uniquely determined.
+
+Whether this mathematical structure reflects fundamental reality or constitutes an effective description remains open.
+
+## 4. Experimental Tests
+
+The framework makes specific predictions testable by near-term experiments:
+
+| Prediction | Current Value | Experiment | Timeline |
+|------------|---------------|------------|----------|
+| δ_CP = 197° | 197° ± 24° | DUNE | 2027-2030 |
+| sin²θ_W = 3/13 | 0.23122 ± 0.00003 | FCC-ee | 2040s |
+| m_s/m_d = 20 | 20.0 ± 1.0 | Lattice QCD | 2030 |
+| N_gen = 3 | 3 | LHC | Ongoing |
+
+**Falsification criteria**: The framework would be refuted by measurement of δ_CP outside [187°, 207°], discovery of a fourth generation fermion, or precision determination of m_s/m_d significantly different from 20. These are genuine experimental tests, not post-hoc accommodations.
+
+## 5. Relation to Other Approaches
+
+**Differs from direct E₈ embedding**: Early attempts to embed Standard Model fields directly in E₈ representations encountered the Distler-Garibaldi obstruction. GIFT uses E₈×E₈ as architecture, not as a direct representation space for fermions.
+
+**Differs from string landscape**: String theory's 10⁵⁰⁰ vacua create a selection problem. GIFT proposes that topological constraints uniquely determine observables, eliminating vacuum degeneracy (though this requires the specific K₇ construction).
+
+**Connection to M-theory**: The 11-dimensional bulk and G₂ compactification are standard in M-theory. GIFT may be viewed as extracting specific predictions from a particular corner of the M-theory landscape.
+
+**Information-geometric interpretation**: The binary duality factor p₂ = 2, the appearance of ln(2) in cosmological formulas, and the dimensional compression 496 → 99 → 4 suggest connections to information theory and quantum error correction.
+
+## 6. Summary
+
+The GIFT framework explores whether Standard Model parameters might be topological invariants rather than free constants. The specific proposal involves E₈×E₈ gauge structure, G₂ holonomy on a 7-manifold K₇ with Betti numbers b₂ = 21 and b₃ = 77, and controlled torsion providing dynamics.
+
+The resulting 39 predictions match experiment to 0.128% mean precision. Whether this reflects fundamental physics or an elaborate coincidence will be determined by experiments, particularly DUNE's measurement of the CP violation phase δ_CP in the coming years.
+
+The framework's value, independent of its physical correctness, lies in demonstrating that geometric principles can substantially constrain particle physics parameters. It provides a concrete example of how topology might replace tuning.
+
+## References
+
+- Main paper: [gift_2_3_main.md](../publications/markdown/gift_2_3_main.md)
+- Mathematical architecture: [S1](../publications/markdown/S1_mathematical_architecture_v23.md)
+- Experimental validation: [S5](../publications/markdown/S5_experimental_validation_v23.md)
+- Formal verification: [gift-framework/core](https://github.com/gift-framework/core)
+- Philosophy: [PHILOSOPHY.md](PHILOSOPHY.md)
+
+---
+
+*GIFT Framework v2.3*

--- a/docs/LEAN_FOR_PHYSICS.md
+++ b/docs/LEAN_FOR_PHYSICS.md
@@ -1,0 +1,244 @@
+# Formal Verification in Theoretical Physics: A Case Study
+
+## Abstract
+
+This document describes the Lean 4 and Coq formalization of the GIFT framework, which derives Standard Model parameters from topological invariants. The formalization verifies 39 exact relations connecting geometric data (Betti numbers, Lie algebra dimensions, cohomological invariants) to physical observables (mixing angles, mass ratios, coupling constants). The verification uses only standard axioms with zero domain-specific assumptions, demonstrating that machine-checked proofs can provide audit trails for theoretical physics claims.
+
+## 1. The Verification Challenge
+
+### 1.1 Why Formalize Physics?
+
+Physical theories involve long chains of mathematical reasoning. A typical derivation might proceed through algebraic manipulations, topological identities, approximations, and numerical estimates. Each step introduces potential for human error. Even peer-reviewed papers contain mistakes that propagate through the literature.
+
+Formal verification addresses this by requiring every step to be machine-checked against foundational axioms. The proof assistant refuses to compile unless each claim follows logically from established facts. This provides:
+
+- **Reproducibility**: Anyone can verify the proofs by running the compiler
+- **Transparency**: Assumptions are explicitly stated in the axiom declarations
+- **Error detection**: Several computational errors were caught during formalization
+- **Clear boundaries**: The distinction between "proven" and "assumed" is sharp
+
+### 1.2 What Can Be Formalized?
+
+Different aspects of physics have different formalization prospects:
+
+| Aspect | Formalizability | Current Status |
+|--------|----------------|----------------|
+| Algebraic identities | High | Well-developed in proof assistants |
+| Arithmetic relations | High | Mature library support |
+| Topological invariants | Medium-High | Active research area |
+| Differential geometry | Medium | Partial coverage in Mathlib |
+| Full dynamical content | Low | Requires analysis formalization |
+| Quantum field theory | Low | Foundational issues remain |
+
+The GIFT formalization focuses on the first three categories: algebraic data (E₈ dimensions, G₂ structure), topological invariants (Betti numbers), and the arithmetic relations connecting them to physical observables.
+
+## 2. The GIFT Formalization
+
+### 2.1 Scope
+
+The formalization covers 39 exact relations verified in both Lean 4 (with Mathlib 4.14+) and Coq (version 8.18). Dual verification in independent proof assistants provides additional confidence: a bug in one system would not reproduce in the other.
+
+**Critical property**: The proofs use zero domain-specific axioms. The only axioms employed are:
+- Lean: `propext` (propositional extensionality), `Quot.sound` (quotient soundness) - both standard
+- Coq: Standard library axioms only
+
+No axiom asserts "the universe has E₈×E₈ gauge symmetry" or "there exists a G₂ manifold with these Betti numbers." The proofs show only that *given* such topological inputs, the physical relations follow by pure computation.
+
+### 2.2 Architecture
+
+The Lean formalization is organized as follows:
+
+| Module | Content | Theorems |
+|--------|---------|----------|
+| `GIFT.Algebra` | E₈ definition, dim = 248, rank = 8 | Core algebraic structures |
+| `GIFT.Topology` | K₇ Betti numbers b₂ = 21, b₃ = 77 | Topological invariants |
+| `GIFT.Relations` | 39 physical relations | Main results |
+| `GIFT.Relations.GaugeSector` | sin²θ_W = 3/13, α_s denominator | Gauge coupling relations |
+| `GIFT.Relations.NeutrinoSector` | δ_CP = 197°, mixing angles | Neutrino observables |
+| `GIFT.Relations.LeptonSector` | Q_Koide = 2/3, mass ratios | Lepton relations |
+| `GIFT.Relations.YukawaDuality` | Visible/hidden sector split | Matter structure |
+| `GIFT.Relations.IrrationalSector` | Golden ratio bounds | Transcendental relations |
+| `GIFT.Certificate` | Master theorem | `all_39_relations_certified` |
+
+The Coq formalization maintains parallel structure with 21 modules.
+
+### 2.3 What is Actually Proven
+
+Each relation is proven as a theorem from the defining topological data. For example:
+
+**Weinberg angle**: The theorem states that 21/(77+14) = 3/13. In Lean:
+
+```lean
+theorem weinberg_angle_certified :
+    (b2_K7 : ℚ) / (b3_K7 + dim_G2) = 3 / 13 := by
+  simp only [b2_K7, b3_K7, dim_G2]
+  norm_num
+```
+
+The proof proceeds by: (1) substituting the definitions (b₂ = 21, b₃ = 77, dim(G₂) = 14), (2) computing 21/91 = 3/13 via `norm_num`, a verified arithmetic tactic.
+
+**Torsion magnitude**: The theorem that 1/(77-14-2) = 1/61:
+
+```lean
+theorem kappa_T_certified :
+    (1 : ℚ) / (b3_K7 - dim_G2 - p2) = 1 / 61 := by
+  simp only [b3_K7, dim_G2, p2]
+  norm_num
+```
+
+**Hierarchy parameter**: The theorem that 496×21/(27×99) = 3472/891:
+
+```lean
+theorem tau_certified :
+    (dim_E8_product * b2_K7 : ℚ) / (dim_J3O * H_star) = 3472 / 891 := by
+  simp only [dim_E8_product, b2_K7, dim_J3O, H_star]
+  norm_num
+```
+
+### 2.4 What is Not Proven
+
+The formalization does not establish:
+
+1. **Existence of K₇**: That a G₂ manifold with Betti numbers (21, 77) exists is established via Joyce's theorem and numerical certification (see Supplement S2), but Joyce's theorem itself is axiomatized, not formalized from first principles.
+
+2. **Physical interpretation**: That sin²θ_W corresponds to electroweak mixing, or that b₂ counts gauge fields, is a physical claim outside the scope of formal verification.
+
+3. **Uniqueness**: Whether other geometric structures could yield similar predictions is not addressed.
+
+4. **Dynamical derivations**: Relations involving differential equations or RG flow are not formalized.
+
+## 3. Technical Details
+
+### 3.1 Lean 4 Implementation
+
+**Dependencies**: Mathlib 4.14.0+
+
+**Modules**: 17 files
+
+**Key theorem**: `all_39_relations_certified` in `GIFT.Certificate.MainTheorem`
+
+**Verification statistics**:
+- 0 `sorry` (incomplete proof markers)
+- 0 domain-specific axioms
+- Full CI pipeline ensures all proofs compile
+
+### 3.2 Coq Implementation
+
+**Version**: Coq 8.18
+
+**Modules**: 21 files
+
+**Parallel structure**: Each Lean theorem has a Coq counterpart
+
+**Verification statistics**:
+- 0 `Admitted` (incomplete proof markers)
+- 0 domain-specific axioms
+
+### 3.3 Verification Statistics
+
+| Metric | Value |
+|--------|-------|
+| Total relations verified | 39 |
+| Proof assistants | 2 (Lean 4, Coq) |
+| Domain axioms | 0 |
+| Incomplete proofs | 0 |
+| CI status | Passing |
+
+## 4. Methodological Implications
+
+### 4.1 For Physics
+
+The formalization demonstrates that theoretical physics claims can have explicit audit trails. Every assumption is declared; every derivation is machine-checked. This does not guarantee physical correctness (the universe may not match the axioms), but it guarantees internal consistency.
+
+Several errors were caught during formalization: off-by-one mistakes in index calculations, sign errors in transcendental approximations, and incorrect cancellations in rational simplification. These would likely have persisted in traditional pen-and-paper work.
+
+### 4.2 For Mathematics
+
+The formalization provides a case study in applying proof assistants to physics-adjacent mathematics. Key techniques include:
+
+- Rational number arithmetic for exact relations
+- Interval arithmetic for bounds on transcendentals
+- Algebraic hierarchy for Lie algebra dimensions
+- Topological abstractions for cohomological data
+
+The E₈ and G₂ structures are defined axiomatically (dimension, rank) rather than constructed explicitly. This suffices for the arithmetic relations while avoiding the complexity of full Lie algebra theory.
+
+### 4.3 Limitations
+
+Formalization proves internal consistency, not external validity. A framework could be internally consistent yet physically wrong. The proofs establish: "If the topological data are as claimed, then the relations hold." Whether the universe actually instantiates this topology is an empirical question.
+
+Continuous mathematics (analysis, differential geometry) remains harder to formalize than discrete mathematics (algebra, combinatorics). The GIFT formalization deliberately focuses on exact arithmetic relations, deferring dynamical content.
+
+## 5. Access and Reproduction
+
+### 5.1 Repository
+
+All proofs are publicly available:
+
+**Repository**: [github.com/gift-framework/core](https://github.com/gift-framework/core)
+
+**Structure**:
+```
+core/
+├── Lean/
+│   ├── GIFT/
+│   │   ├── Algebra.lean
+│   │   ├── Topology.lean
+│   │   ├── Relations/
+│   │   │   ├── GaugeSector.lean
+│   │   │   ├── NeutrinoSector.lean
+│   │   │   ├── LeptonSector.lean
+│   │   │   ├── YukawaDuality.lean
+│   │   │   └── ...
+│   │   └── Certificate.lean
+│   └── lakefile.lean
+└── Coq/
+    ├── GIFT/
+    │   ├── Algebra.v
+    │   ├── Topology.v
+    │   └── ...
+    └── _CoqProject
+```
+
+### 5.2 Verification
+
+To verify the Lean proofs:
+
+```bash
+git clone https://github.com/gift-framework/core
+cd core/Lean
+lake build
+```
+
+To verify the Coq proofs:
+
+```bash
+cd core/Coq
+make
+```
+
+Both should complete without errors on standard installations.
+
+### 5.3 Continuous Integration
+
+The repository maintains CI pipelines that rebuild all proofs on each commit. Green build status indicates all theorems verify with current Mathlib/Coq versions.
+
+## 6. Summary
+
+The GIFT formalization demonstrates that machine-verified proofs can apply to theoretical physics. The 39 relations connecting E₈×E₈ and K₇ topology to Standard Model observables have been proven in both Lean 4 and Coq, using zero domain-specific axioms.
+
+This establishes internal consistency: given the stated topological inputs, the physical relations follow by pure computation. Whether the inputs describe physical reality remains an empirical question, to be addressed by experiments like DUNE's measurement of δ_CP.
+
+The methodological contribution is independent of GIFT's physical correctness. Formal verification provides transparent, reproducible, and auditable derivations - properties valuable for any mathematical framework in physics.
+
+## References
+
+- GIFT main paper: [gift_2_3_main.md](../publications/markdown/gift_2_3_main.md)
+- K₇ construction: [S2](../publications/markdown/S2_K7_manifold_construction_v23.md)
+- Complete derivations: [S4](../publications/markdown/S4_complete_derivations_v23.md)
+- Observable reference: [GIFT_v23_Observable_Reference.md](../publications/references/GIFT_v23_Observable_Reference.md)
+- Code repository: [github.com/gift-framework/core](https://github.com/gift-framework/core)
+
+---
+
+*GIFT Framework v2.3 - Formal Verification Documentation*


### PR DESCRIPTION
…lization

Add three audience-targeted papers to docs/:

- GIFTPY_FOR_GEOMETERS.md: G₂ metric construction pipeline for differential geometers. Covers TCS construction, PINN metric approximation, topological extraction, and formal verification bridge to Lean 4.

- INFO_GEO_FOR_PHYSICISTS.md: Information-geometric perspective on SM parameters for theoretical physicists. Covers E₈×E₈ gauge structure, K₇ manifold, dimensional reduction, and experimental tests.

- LEAN_FOR_PHYSICS.md: Formal verification case study for proof assistant users. Covers 39 machine-verified relations in Lean 4 + Coq with zero domain-specific axioms.

Update README.md navigation with domain-specific guides section.

Each paper is self-contained, technical, and neutral in tone (~800-1200 words).

🤖 Generated with [Claude Code](https://claude.com/claude-code)