### PR TITLE
docs: Synchronize framework files to v3.0

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -1,319 +1,195 @@
 # Citation Guide
 
-This document provides formal citation formats for the GIFT Framework v3.0.
+Citation formats for the GIFT Framework v3.0.
 
 ## Software Citation (Recommended)
 
 ### BibTeX
 
 ```bibtex
-@software{gift_framework_v23_2025,
-  title={GIFT Framework v3.0: Geometric Information Field Theory - Zero Parameter Paradigm},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  url={https://github.com/gift-framework/GIFT},
-  version={3.0.0},
-  license={MIT},
-  note={39 observables, 0.128\% precision, all quantities structurally determined from E₈×E₈ topology}
+@software{gift_framework_v30,
+  title   = {GIFT Framework v3.0: Geometric Information Field Theory},
+  author  = {de La Fournière, Brieuc},
+  year    = {2025},
+  url     = {https://github.com/gift-framework/GIFT},
+  version = {3.0.0},
+  license = {MIT},
+  note    = {18 dimensionless observables, 0.197\% precision, 165+ certified relations}
 }
 ```
 
 ### APA Style
 
 ```
-de La Fournière, B. (2025). GIFT Framework v3.0: Geometric Information Field Theory - Zero Parameter Paradigm (Version 2.3) [Software]. GitHub. https://github.com/gift-framework/GIFT
+de La Fournière, B. (2025). GIFT Framework v3.0: Geometric Information Field Theory (Version 3.0) [Software]. GitHub. https://github.com/gift-framework/GIFT
 ```
 
 ### Chicago Style
 
 ```
-de La Fournière, Brieuc. "GIFT Framework v3.0: Geometric Information Field Theory - Zero Parameter Paradigm." Version 3.0.0. GitHub, 2025. https://github.com/gift-framework/GIFT.
+de La Fournière, Brieuc. "GIFT Framework v3.0: Geometric Information Field Theory." Version 3.0.0. GitHub, 2025. https://github.com/gift-framework/GIFT.
 ```
+
+---
 
 ## Theoretical Framework Citation
 
 ### BibTeX
 
 ```bibtex
-@article{gift_framework_v23_theory_2025,
-  title={Geometric Information Field Theory v3.0: Topological Unification of Standard Model Parameters Through Torsional Dynamics},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  journal={arXiv preprint},
-  note={Mean deviation 0.128\% across 39 observables, zero continuous adjustable parameters, 165+ proven exact relations},
-  url={https://github.com/gift-framework/GIFT}
+@article{gift_theory_v30,
+  title  = {Geometric Information Field Theory v3.0: Topological Determination of Standard Model Parameters},
+  author = {de La Fournière, Brieuc},
+  year   = {2025},
+  note   = {Mean deviation 0.197\% across 18 dimensionless observables, zero continuous adjustable parameters, 165+ proven exact relations},
+  url    = {https://github.com/gift-framework/GIFT}
 }
 ```
-
-## Technical Supplement Citation
-
-### BibTeX
-
-```bibtex
-@techreport{gift_technical_v23_2025,
-  title={GIFT Framework v3.0 - Technical Supplements: Complete Mathematical Derivations},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  institution={GIFT Framework},
-  type={Technical Supplement},
-  note={Seven detailed supplements (S1-S7) with 165+ proven exact relations and all derivations},
-  url={https://github.com/gift-framework/GIFT/tree/main/publications/supplements}
-}
-```
-
-## Specific Results Citation
-
-When citing specific predictions or results, include the relevant section:
-
-### Example: Neutrino Predictions
-
-```bibtex
-@misc{gift_neutrino_predictions_2025,
-  title={Complete Neutrino Mixing Parameter Predictions from E₈×E₈ Topology},
-  author={{GIFT Framework Team}},
-  year={2025},
-  howpublished={GIFT Framework v3.0, Main Paper Section 8.4},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/gift_3_0_main.md}
-}
-```
-
-### Example: Exact Relations
-
-```bibtex
-@misc{gift_exact_relations_2025,
-  title={Rigorously Proven Exact Relations in Fundamental Physics},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  howpublished={GIFT Framework v3.0, Supplement S4},
-  note={165+ proven exact relations including sin²θ_W = 3/13, κ_T = 1/61, det(g) = 65/32, γ_GIFT = 511/884, θ₂₃ = 85/99, α⁻¹ base = 137, α⁻¹ complete = 267489/1952, Yukawa duality, |W(E₈)| = 696729600},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/S4_complete_derivations_v30.md}
-}
-```
-
-### Example: CP Violation Phase
-
-```bibtex
-@misc{gift_cp_violation_2025,
-  title={Exact Topological Formula for CP Violation Phase: δ_CP = 197°},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  howpublished={GIFT Framework v3.0, Supplement S4},
-  note={Formula: δ_CP = dim(K₇)×dim(G₂) + H* = 7×14 + 99 = 197°, exact},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/S4_complete_derivations_v30.md}
-}
-```
-
-### Example: Generation Number
-
-```bibtex
-@misc{gift_generation_number_2025,
-  title={Topological Proof of Three Fermion Generations},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  howpublished={GIFT Framework v3.0, Supplement S4},
-  note={N_gen = 3 from Atiyah-Singer index theorem on K₇},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/S4_complete_derivations_v30.md}
-}
-```
-
-### Example: Cosmological Predictions
-
-```bibtex
-@misc{gift_cosmology_unified_2025,
-  title={Unified Cosmological Predictions: Dark Energy from Binary Information Architecture},
-  author={{GIFT Framework Team}},
-  year={2025},
-  howpublished={GIFT Framework v3.0, Main Paper Section 8.8},
-  note={Ω_DE = ln(2)×98/99, precision 0.10\%},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/gift_3_0_main.md}
-}
-```
-
-## Citing Specific Supplements
-
-### Supplement S1: Mathematical Architecture
-
-```bibtex
-@techreport{gift_supp_s1_2025,
-  title={GIFT Supplement S1: Mathematical Architecture},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  institution={GIFT Framework},
-  note={E₈ structure, K₇ manifold, G₂ holonomy, cohomology},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/S1_mathematical_architecture_v30.md}
-}
-```
-
-### Supplement S4: Complete Derivations
-
-```bibtex
-@techreport{gift_supp_s4_2025,
-  title={GIFT Supplement S4: Complete Derivations},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  institution={GIFT Framework},
-  note={165+ proven exact relations with proofs, all 39 observable derivations},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/S4_complete_derivations_v30.md}
-}
-```
-
-### Supplement S5: Experimental Validation
-
-```bibtex
-@techreport{gift_supp_s5_2025,
-  title={GIFT Supplement S5: Experimental Validation},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  institution={GIFT Framework},
-  note={Data comparison, statistical analysis, falsification protocol},
-  url={https://github.com/gift-framework/GIFT/blob/main/publications/markdown/S5_experimental_validation_v30.md}
-}
-```
-
-## DOI Information
-
-**Status**: DOI registration pending. Once registered, this section will be updated with the official DOI.
-
-Planned DOI provider: Zenodo (10.5281/zenodo.*)
-
-When DOI becomes available, cite using:
-
-```bibtex
-@software{gift_framework_v23_2025,
-  title={GIFT Framework v3.0: Geometric Information Field Theory},
-  author={{Brieuc de La Fournière}},
-  year={2025},
-  doi={10.5281/zenodo.XXXXXXX},  % TODO: Update with actual DOI when registered
-  url={https://github.com/gift-framework/GIFT},
-  version={3.0.0}
-}
-```
-
-To register a DOI for this repository:
-1. Create a GitHub release (v3.0.1)
-2. Link repository to Zenodo via GitHub integration
-3. Generate DOI automatically through Zenodo
-4. Update this file with the assigned DOI
-
-Check repository for updates on DOI availability.
-
-## Version History
-
-- **v3.0.4** (2025-12-08): Current version with 0.197% precision, zero parameters, 39 observables, 165+ proven relations (giftpy v1.5.0)
-- **v3.0.3** (2025-12-05): 165+ proven relations (+ 4 irrational sector), giftpy v1.4.0
-- **v3.0.1** (2025-12-04): 25 proven relations (12 topological extension), giftpy v1.1.0
-- **v3.0.0** (2025-12-09): Dual Lean 4 + Coq verification, 13 original proven relations
-- **v2.2.0** (2025-11-27): Zero-parameter paradigm, 39 observables
-- **v2.1.0** (2025-11-22): Legacy, see `legacy/legacy_v2.1/`
-- **v2.0.0** (2025-10-24): Legacy, see `legacy/legacy_v2.0/`
-- **v1.0.0** (Archived): Available in `legacy/legacy_v1/`
-
-## Author Attribution
-
-The GIFT Framework Team includes all contributors to the theoretical development, computational implementation, and documentation. For specific author lists in publications, consult individual documents.
-
-Current framework developed by:
-- Brieuc de La Fournière (lead developer)
-- Contributors (see GitHub repository)
-
-## Contact Information
-
-For questions about citation or usage:
-- **Repository**: https://github.com/gift-framework/GIFT
-- **Issues**: https://github.com/gift-framework/GIFT/issues
-- **Documentation**: https://github.com/gift-framework/GIFT/blob/main/README.md
-
-## Usage in Publications
-
-When using GIFT predictions in your research:
-
-1. **Cite framework**: Use software citation above
-2. **Cite specific results**: Use appropriate supplement citation
-3. **Specify version**: Always include version number (v3.0.3)
-4. **Note modifications**: If you modify predictions, clearly state changes
-5. **Link to repository**: Include GitHub URL for reproducibility
-
-### Example Usage in Paper
-
-> "We compare our measurements with predictions from the Geometric Information Field Theory (GIFT) framework [1], which derives Standard Model parameters from E₈×E₈ topology. The GIFT prediction for the CP violation phase is δ_CP = 197° [2], obtained from the exact formula δ_CP = dim(K₇)×dim(G₂) + H* = 7×14 + 99 = 197°."
->
-> [1] Brieuc de La Fournière, "GIFT Framework v3.0: Geometric Information Field Theory," v3.0.1, 2025, https://github.com/gift-framework/GIFT
->
-> [2] Brieuc de La Fournière, "GIFT Supplement S4: Complete Derivations," 2025.
-
-## License Attribution
-
-This work is licensed under the MIT License. When using or citing this framework:
-
-1. **No copyright restrictions**: Free to use in any context
-2. **Attribution required**: Please cite appropriately
-3. **No warranty**: Framework provided "as is" for scientific exploration
-4. **Modifications allowed**: Clearly note any changes made
-
-See [LICENSE](LICENSE) file for complete terms.
-
-## Citing Computational Results
-
-When using computational validation results:
-
-```bibtex
-@software{gift_validation_2025,
-  title={GIFT Framework v3.0: Statistical Validation},
-  author={{GIFT Framework Team}},
-  year={2025},
-  url={https://github.com/gift-framework/GIFT/tree/main/statistical_validation},
-  note={Monte Carlo validation and statistical significance tests}
-}
-```
-
-Notebooks are also available via Binder:
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/gift-framework/GIFT/main)
-
-## Citation Best Practices
-
-### For Theorists
-
-Cite:
-- Main framework (software citation)
-- Relevant mathematical supplements (S1, S4)
-- Specific theorems or derivations used
-
-### For Experimentalists
-
-Cite:
-- Main framework (software citation)
-- Experimental validation supplement (S5)
-- Specific predictions being tested
-
-### For Students and Educators
-
-Cite:
-- Main framework (software citation)
-- Quick start guide and documentation
-- Specific sections or examples used
-
-## Updates and Corrections
-
-This citation guide is updated with:
-- New publication formats
-- DOI registration
-- Additional citation examples
-- Community feedback
-
-Check repository for latest version.
-
-## Questions
-
-For citation-related questions:
-1. Consult this guide first
-2. Check `docs/FAQ.md` for common questions
-3. Open issue at https://github.com/gift-framework/GIFT/issues
-4. Tag as "citation" for citation-specific queries
 
 ---
 
-Thank you for citing GIFT in your work. Proper attribution helps build the scientific record and enables others to find and verify results.
+## Citing Specific Documents
 
-**Repository**: https://github.com/gift-framework/GIFT
+### Main Paper
 
-**Version**: 2.3 (2025-12-09)
+```bibtex
+@misc{gift_main_v30,
+  title        = {Geometric Information Field Theory: Topological Determination of Standard Model Parameters},
+  author       = {de La Fournière, Brieuc},
+  year         = {2025},
+  howpublished = {GIFT Framework v3.0},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3_main.md}
+}
+```
+
+### S1: Foundations
+
+```bibtex
+@misc{gift_s1_foundations,
+  title        = {GIFT S1: Mathematical Foundations - E₈, G₂, K₇},
+  author       = {de La Fournière, Brieuc},
+  year         = {2025},
+  howpublished = {GIFT Framework v3.0, Supplement S1},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3_S1_foundations.md}
+}
+```
+
+### S2: Derivations
+
+```bibtex
+@misc{gift_s2_derivations,
+  title        = {GIFT S2: Complete Derivations - 18 Dimensionless Observables},
+  author       = {de La Fournière, Brieuc},
+  year         = {2025},
+  howpublished = {GIFT Framework v3.0, Supplement S2},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3_S2_derivations.md}
+}
+```
+
+---
+
+## Citing Specific Results
+
+### CP Violation Phase
+
+```bibtex
+@misc{gift_cp_violation,
+  title        = {Exact Topological Formula for CP Violation Phase: δ_CP = 197°},
+  author       = {de La Fournière, Brieuc},
+  year         = {2025},
+  howpublished = {GIFT Framework v3.0},
+  note         = {Formula: δ_CP = dim(K₇)×dim(G₂) + H* = 7×14 + 99 = 197°},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3_S2_derivations.md}
+}
+```
+
+### Weinberg Angle
+
+```bibtex
+@misc{gift_weinberg_angle,
+  title        = {Topological Derivation of Weinberg Angle: sin²θ_W = 3/13},
+  author       = {de La Fournière, Brieuc},
+  year         = {2025},
+  howpublished = {GIFT Framework v3.0},
+  note         = {Formula: sin²θ_W = b₂/(b₃ + dim(G₂)) = 21/91 = 3/13},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3_S2_derivations.md}
+}
+```
+
+### Generation Number
+
+```bibtex
+@misc{gift_generation_number,
+  title        = {Topological Proof of Three Fermion Generations},
+  author       = {de La Fournière, Brieuc},
+  year         = {2025},
+  howpublished = {GIFT Framework v3.0},
+  note         = {N_gen = 3 from Atiyah-Singer index theorem on K₇},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3_S1_foundations.md}
+}
+```
+
+---
+
+## Formal Verification
+
+```bibtex
+@software{gift_core_v20,
+  title   = {GIFT Core: Formal Verification in Lean 4 + Coq},
+  author  = {de La Fournière, Brieuc},
+  year    = {2025},
+  url     = {https://github.com/gift-framework/core},
+  version = {2.0.0},
+  note    = {165+ relations verified, zero axioms, K₇ metric pipeline}
+}
+```
+
+---
+
+## DOI Information
+
+| Archive | Link |
+|---------|------|
+| Zenodo | [10.5281/zenodo.17751250](https://doi.org/10.5281/zenodo.17751250) |
+| ResearchGate | [Author page](https://www.researchgate.net/profile/Brieuc-De-La-Fourniere) |
+
+---
+
+## Version History
+
+| Version | Date | Highlights |
+|---------|------|------------|
+| 3.0.0 | 2025-12-09 | Major release: 165+ certified relations, Fibonacci/Monster/McKay |
+| 2.3.x | 2025-12 | Dual Lean 4 + Coq verification |
+| 2.2.0 | 2025-11-27 | Zero-parameter paradigm |
+| 2.1.0 | 2025-11-22 | Torsional dynamics |
+| 2.0.0 | 2025-10-24 | Framework reorganization |
+
+---
+
+## Usage in Publications
+
+When using GIFT predictions:
+
+1. **Cite framework** - Use software citation above
+2. **Cite specific results** - Use appropriate document citation
+3. **Specify version** - Always include version number (v3.0)
+4. **Link repository** - Include GitHub URL for reproducibility
+
+### Example
+
+> "We compare our measurements with predictions from the Geometric Information Field Theory (GIFT) framework [1], which derives Standard Model parameters from E₈×E₈ topology. The GIFT prediction for the CP violation phase is δ_CP = 197° [2]."
+>
+> [1] de La Fournière, B. "GIFT Framework v3.0," 2025, https://github.com/gift-framework/GIFT
+>
+> [2] de La Fournière, B. "GIFT S2: Complete Derivations," 2025.
+
+---
+
+## License
+
+MIT License - See [LICENSE](LICENSE)
+
+---
+
+**Version**: 3.0.0 (2025-12-11)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to GIFT.
 
 ## Documentation Contributions
 
-This repository contains the theoretical documentation for GIFT v2.3. Contributions welcome:
+This repository contains the theoretical documentation for GIFT v3.0. Contributions welcome:
 
 - **Clarifications**: Improve explanations of concepts
 - **Corrections**: Fix errors in derivations or references
@@ -25,7 +25,7 @@ This repository contains the theoretical documentation for GIFT v2.3. Contributi
 
 ## Code Contributions
 
-For code contributions (K7 metric, formal proofs, validation), see [gift-framework/core](https://github.com/gift-framework/core).
+For code contributions (K₇ metric, formal proofs, giftpy), see [gift-framework/core](https://github.com/gift-framework/core).
 
 ## License
 

--- a/docs/EXPERIMENTAL_VALIDATION.md
+++ b/docs/EXPERIMENTAL_VALIDATION.md
@@ -4,13 +4,13 @@ Current experimental status of GIFT predictions, precision comparisons, and time
 
 ## Overview
 
-The GIFT framework v2.3 makes 39 predictions (27 dimensionless + 12 dimensional) with mean experimental deviation of 0.197%. This document tracks:
+The GIFT framework v3.0 makes 23 predictions (10 structural + 13 dimensionless ratios) with mean experimental deviation of 0.197%. This document tracks:
 - Current experimental status for each prediction
 - Precision evolution over time
 - Planned experiments and timelines
 - Criteria for validation or falsification
 
-**Last updated**: 2025-12-03 (v2.3.0 release)
+**Last updated**: 2025-12-11 (v3.0.0)
 
 ## Current Experimental Status Summary
 
@@ -346,12 +346,12 @@ No sector shows systematic problems. All perform well.
 - Perfect fit by construction (parameters chosen to match)
 - No predictive power for these 19 numbers
 
-**GIFT v2.3.1**: Zero continuous adjustable parameters, 39 predictions
+**GIFT v3.0**: Zero continuous adjustable parameters, 23 predictions
 - Mean deviation 0.197% without adjusting
 - Genuine predictive power
 - Complete elimination of free parameters
 - All quantities structurally determined
-- 54 relations formally verified in both Lean 4 and Coq (13 original + 12 topological + 10 Yukawa + 4 irrational + 5 exceptional + 6 base decomp + 4 extended)
+- 165+ relations formally verified in Lean 4 + Coq
 
 **Other unification attempts**:
 - SU(5) GUT: Incorrect sin²θ_W prediction (~0.20 vs 0.23)

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # GIFT Framework - Documentation
 
-Supporting documentation for the GIFT Framework v2.3.
+Supporting documentation for the GIFT Framework v3.0.
 
 ## Contents
 
@@ -18,14 +18,27 @@ Supporting documentation for the GIFT Framework v2.3.
 Static visualizations are available in the [`figures/`](figures/) directory:
 - E₈ root system projections
 - K₇ TCS construction diagrams
-- Framework overview (Metro Map)
+- Lean blueprints (interactive)
 
 ## Main Documentation
 
-- [Main Paper](../publications/markdown/gift_2_3_main.md) - Complete theoretical framework
-- [Supplements S1-S7](../publications/markdown/) - Mathematical details
-- [Observable Reference](../publications/references/GIFT_v23_Observable_Reference.md) - All 39 observables
+- [Main Paper](../publications/markdown/GIFT_v3_main.md) - Complete theoretical framework
+- [S1: Foundations](../publications/markdown/GIFT_v3_S1_foundations.md) - E₈, G₂, K₇ mathematical construction
+- [S2: Derivations](../publications/markdown/GIFT_v3_S2_derivations.md) - 18 dimensionless derivations
+- [Observables CSV](../publications/references/39_observables.csv) - Machine-readable data
+
+## Exploratory References
+
+| Document | Content |
+|----------|---------|
+| [Yukawa & Mixing](../publications/references/yukawa_mixing.md) | CKM/PMNS matrices |
+| [Sequences & Primes](../publications/references/sequences_prime_atlas.md) | Fibonacci, Prime Atlas |
+| [Monster & Moonshine](../publications/references/monster_moonshine.md) | Monster group, j-invariant |
+
+## Legacy
+
+Historical supplements (v2.3/v3.0 drafts) archived in [`legacy/`](legacy/).
 
 ---
 
-Part of GIFT Framework v2.3 - MIT License
+Part of GIFT Framework v3.0 - MIT License

--- a/publications/references/README.md
+++ b/publications/references/README.md
@@ -1,96 +1,64 @@
 # GIFT Reference Documents
 
-This folder contains consolidated reference documents for the GIFT framework.
+Exploratory and reference documents for the GIFT framework v3.0.
 
 ---
 
-## Document Index
+## Contents
 
-### Core Observable References
-
-| Document | Description | Version |
-|----------|-------------|---------|
-| **GIFT_v30_Observable_Reference.md** | Complete observable predictions (masses, couplings, angles) | v3.0 |
-| **GIFT_v30_Geometric_Justifications.md** | Geometric derivations from K₇ topology | v3.0 |
-| **GIFT_v30_Statistical_Validation.md** | Statistical analysis of predictions vs experiment | v3.0 |
-
-### Thematic References
-
-| Document | Description | Topics |
-|----------|-------------|--------|
-| **GIFT_Mathematical_Correspondences.md** | Number-theoretic connections | Fibonacci, Lucas, Fermat, Bernoulli, Moonshine, Monster group, Golden ratio |
-| **GIFT_Cosmology_Reference.md** | Cosmological parameters | Hubble tension, Ω_DE, Ω_DM, age of universe |
-| **GIFT_Scale_Bridge.md** | Absolute mass derivation | m_e from M_Pl, hierarchy problem |
-
-### Data Files
+### Data
 
 | File | Description |
 |------|-------------|
-| **39_observables.csv** | Raw data for 39 physical observables |
+| [39_observables.csv](39_observables.csv) | Machine-readable observable data |
+
+### Exploratory References
+
+| Document | Content | Status |
+|----------|---------|--------|
+| [yukawa_mixing.md](yukawa_mixing.md) | CKM/PMNS matrices, Yukawa couplings | Exploratory |
+| [sequences_prime_atlas.md](sequences_prime_atlas.md) | Fibonacci embedding, Prime Atlas | Observation |
+| [monster_moonshine.md](monster_moonshine.md) | Monster group, j-invariant | Speculative |
+| [dimensional_observables.md](dimensional_observables.md) | Absolute masses (heuristic) | Heuristic |
+| [theoretical_extensions.md](theoretical_extensions.md) | M-theory, quantum gravity | Theoretical |
 
 ---
 
-## Quick Navigation
+## Status Legend
 
-### By Topic
-
-**Particle Physics**
-- Masses → Observable_Reference, Scale_Bridge
-- Mixing angles → Observable_Reference
-- Couplings → Observable_Reference, Geometric_Justifications
-
-**Cosmology**
-- Hubble constant → Cosmology_Reference
-- Dark energy/matter → Cosmology_Reference
-- Age of universe → Cosmology_Reference
-
-**Mathematical Structures**
-- Fibonacci/Lucas → Mathematical_Correspondences
-- Moonshine/Monster → Mathematical_Correspondences
-- Golden ratio φ → Mathematical_Correspondences, Scale_Bridge
-- Bernoulli numbers → Mathematical_Correspondences
-- Prime numbers → Mathematical_Correspondences
-
-**Foundational**
-- K₇ topology → Geometric_Justifications
-- Betti numbers (b₂=21, b₃=77) → all documents
-- E₈ structure → Mathematical_Correspondences
+| Status | Meaning |
+|--------|---------|
+| **Exploratory** | Promising direction, needs verification |
+| **Observation** | Mathematical pattern, interpretation unclear |
+| **Speculative** | Interesting connection, highly tentative |
+| **Heuristic** | Approximate or phenomenological |
+| **Theoretical** | Theoretical speculation |
 
 ---
 
-## Version History
-
-| Version | Date | Changes |
-|---------|------|---------|
-| v2.3 | 2025-12 | Legacy documents |
-| v3.0 | 2025-12 | Updated with 165+ relations |
-| Consolidated | 2025-12-10 | Added Mathematical_Correspondences, Cosmology_Reference, Scale_Bridge |
-
----
-
-## Related Documentation
-
-- **../main/** - Main publication drafts
-- **../../docs/technical/** - Technical documentation (Lean formalization)
-- **../../docs/wip/** - Work in progress documents
-
----
-
-## Key Constants Quick Reference
+## Key Constants
 
 | Constant | Value | Role |
 |----------|-------|------|
 | b₂ | 21 | Second Betti number |
 | b₃ | 77 | Third Betti number |
 | H* | 99 | b₂ + b₃ + 1 |
-| dim_E₈ | 248 | E₈ dimension |
-| rank_E₈ | 8 | E₈ rank |
-| dim_G₂ | 14 | G₂ dimension |
-| dim_K₇ | 7 | Compact manifold |
+| dim(E₈) | 248 | E₈ dimension |
+| rank(E₈) | 8 | E₈ rank |
+| dim(G₂) | 14 | G₂ dimension |
+| dim(K₇) | 7 | Compact manifold |
 | N_gen | 3 | Generations |
 | κ_T⁻¹ | 61 | Inverse torsion |
-| φ | 1.618... | Golden ratio |
 
 ---
 
-*Last updated: 2025-12-10*
+## Core Documents
+
+For the main framework documents, see [`../markdown/`](../markdown/):
+- [GIFT_v3_main.md](../markdown/GIFT_v3_main.md) - Main paper
+- [GIFT_v3_S1_foundations.md](../markdown/GIFT_v3_S1_foundations.md) - Foundations
+- [GIFT_v3_S2_derivations.md](../markdown/GIFT_v3_S2_derivations.md) - Derivations
+
+---
+
+*Part of GIFT Framework v3.0*


### PR DESCRIPTION
Update all documentation files to reference v3.0 as canonical version:

- docs/README.md: Point to GIFT_v3_main.md, S1, S2 (was gift_2_3_main.md)
- CITATION.md: Harmonize all BibTeX entries and version refs to v3.0
- CONTRIBUTING.md: Update version reference
- publications/references/README.md: Reflect actual file structure
- docs/EXPERIMENTAL_VALIDATION.md: Update version and stats to v3.0

Canonical source: publications/markdown/GIFT_v3_*.md