### PR TITLE
Sync publications with validation JSON results

### DIFF
--- a/publications/markdown/GIFT_v3_S2_derivations.md
+++ b/publications/markdown/GIFT_v3_S2_derivations.md
@@ -213,7 +213,7 @@ $$\alpha_s(M_Z) = \frac{\sqrt{2}}{\dim(G_2) - p_2} = \frac{\sqrt{2}}{14 - 2} = \
 |----------|-------|
 | Experimental | 0.1179 ± 0.0009 |
 | GIFT prediction | 0.11785 |
-| Deviation | 0.04% |
+| Deviation | 0.042% |
 
 **Status**: TOPOLOGICAL ∎
 
@@ -241,7 +241,7 @@ $$Q = \frac{m_e + m_\mu + m_\tau}{(\sqrt{m_e} + \sqrt{m_\mu} + \sqrt{m_\tau})^2}
 |----------|-------|
 | Experimental | 0.666661 ± 0.000007 |
 | GIFT prediction | 0.666667 |
-| Deviation | 0.001% |
+| Deviation | 0.0009% |
 
 **Status**: PROVEN ∎
 
@@ -268,7 +268,7 @@ $$3477 = 3 \times 19 \times 61 = N_{gen} \times prime(8) \times \kappa_T^{-1}$$
 |----------|-------|
 | Experimental | 3477.15 ± 0.05 |
 | GIFT prediction | 3477 (exact) |
-| Deviation | 0.004% |
+| Deviation | 0.0043% |
 
 **Status**: PROVEN ∎
 
@@ -295,7 +295,7 @@ $$\frac{m_\mu}{m_e} = [\dim(J_3(\mathbb{O}))]^\phi = 27^\phi = 207.012$$
 |----------|-------|
 | Experimental | 206.768 |
 | GIFT prediction | 207.01 |
-| Deviation | 0.118% |
+| Deviation | 0.1179% |
 
 **Status**: TOPOLOGICAL ∎
 
@@ -374,7 +374,7 @@ $$\theta_{13} = \frac{\pi}{b_2(K_7)} = \frac{\pi}{21} = 8.571°$$
 |----------|-------|
 | Experimental (NuFIT 5.3) | 8.54° ± 0.12° |
 | GIFT prediction | 8.571° |
-| Deviation | 0.36% |
+| Deviation | 0.368% |
 
 **Status**: TOPOLOGICAL ∎
 
@@ -397,7 +397,7 @@ $$\theta_{23} = \frac{\text{rank}(E_8) + b_3(K_7)}{H^*} \text{ radians} = \frac{
 |----------|-------|
 | Experimental (NuFIT 5.3) | 49.3° ± 1.0° |
 | GIFT prediction | 49.193° |
-| Deviation | 0.22% |
+| Deviation | 0.216% |
 
 **Status**: TOPOLOGICAL ∎
 
@@ -426,8 +426,8 @@ $$\gamma_{\text{GIFT}} = \frac{2 \cdot \text{rank}(E_8) + 5 \cdot H^*}{10 \cdot 
 | Quantity | Value |
 |----------|-------|
 | Experimental (NuFIT 5.3) | 33.41° ± 0.75° |
-| GIFT prediction | 33.419° |
-| Deviation | 0.027% |
+| GIFT prediction | 33.40° |
+| Deviation | 0.030% |
 
 **Status**: TOPOLOGICAL ∎
 
@@ -458,7 +458,7 @@ $$\lambda_H = \frac{\sqrt{\dim(G_2) + N_{gen}}}{2^{\text{Weyl}}} = \frac{\sqrt{1
 |----------|-------|
 | Experimental | 0.129 ± 0.003 |
 | GIFT prediction | 0.12885 |
-| Deviation | 0.07% |
+| Deviation | 0.119% |
 
 **Status**: PROVEN ∎
 
@@ -485,7 +485,7 @@ $$\ln\left(\frac{\dim(G_2)}{\dim(K_7)}\right) = \ln(2)$$
 |----------|-------|
 | Experimental (Planck 2020) | 0.6847 ± 0.0073 |
 | GIFT prediction | 0.6861 |
-| Deviation | 0.21% |
+| Deviation | 0.211% |
 
 **Status**: PROVEN ∎
 
@@ -512,7 +512,7 @@ $$n_s = \frac{\zeta(D_{bulk})}{\zeta(\text{Weyl})} = \frac{\zeta(11)}{\zeta(5)} 
 |----------|-------|
 | Experimental (Planck 2020) | 0.9649 ± 0.0042 |
 | GIFT prediction | 0.9649 |
-| Deviation | 0.00% |
+| Deviation | 0.004% |
 
 **Status**: PROVEN ∎
 
@@ -541,7 +541,7 @@ $$= 128 + 9 + \frac{65}{32} \times \frac{1}{61} = 137.033$$
 |----------|-------|
 | Experimental | 137.035999 |
 | GIFT prediction | 137.033 |
-| Deviation | 0.0022% |
+| Deviation | 0.002% |
 
 **Status**: TOPOLOGICAL ∎
 
@@ -557,19 +557,19 @@ $$= 128 + 9 + \frac{65}{32} \times \frac{1}{61} = 137.033$$
 | 2 | τ | 496×21/(27×99) | 3472/891 | - | - | PROVEN |
 | 3 | κ_T | 1/(77-14-2) | 1/61 | - | - | TOPOLOGICAL |
 | 4 | det(g) | 5×13/32 | 65/32 | - | - | TOPOLOGICAL |
-| 5 | sin²θ_W | 21/91 | 3/13 | 0.23122 | 0.20% | PROVEN |
-| 6 | α_s | √2/12 | 0.11785 | 0.1179 | 0.04% | TOPOLOGICAL |
-| 7 | Q_Koide | 14/21 | 2/3 | 0.6667 | 0.001% | PROVEN |
-| 8 | m_τ/m_e | 7+2480+990 | 3477 | 3477.15 | 0.004% | PROVEN |
-| 9 | m_μ/m_e | 27^φ | 207.01 | 206.77 | 0.12% | TOPOLOGICAL |
+| 5 | sin²θ_W | 21/91 | 3/13 | 0.23122 | 0.195% | PROVEN |
+| 6 | α_s | √2/12 | 0.11785 | 0.1179 | 0.042% | TOPOLOGICAL |
+| 7 | Q_Koide | 14/21 | 2/3 | 0.666661 | 0.0009% | PROVEN |
+| 8 | m_τ/m_e | 7+2480+990 | 3477 | 3477.15 | 0.0043% | PROVEN |
+| 9 | m_μ/m_e | 27^φ | 207.01 | 206.768 | 0.118% | TOPOLOGICAL |
 | 10 | m_s/m_d | 4×5 | 20 | 20.0 | 0.00% | PROVEN |
 | 11 | δ_CP | 98+99 | 197° | 197° | 0.00% | PROVEN |
-| 12 | θ₁₃ | π/21 | 8.57° | 8.54° | 0.36% | TOPOLOGICAL |
-| 13 | θ₂₃ | 85/99 rad | 49.19° | 49.3° | 0.22% | TOPOLOGICAL |
-| 14 | θ₁₂ | arctan(...) | 33.42° | 33.41° | 0.03% | TOPOLOGICAL |
-| 15 | λ_H | √17/32 | 0.1289 | 0.129 | 0.07% | PROVEN |
-| 16 | Ω_DE | ln(2)×98/99 | 0.6861 | 0.6847 | 0.21% | PROVEN |
-| 17 | n_s | ζ(11)/ζ(5) | 0.9649 | 0.9649 | 0.00% | PROVEN |
+| 12 | θ₁₃ | π/21 | 8.57° | 8.54° | 0.368% | TOPOLOGICAL |
+| 13 | θ₂₃ | (rank+b3)/H* | 49.19° | 49.3° | 0.216% | TOPOLOGICAL |
+| 14 | θ₁₂ | arctan(...) | 33.40° | 33.41° | 0.030% | TOPOLOGICAL |
+| 15 | λ_H | √17/32 | 0.1288 | 0.129 | 0.119% | PROVEN |
+| 16 | Ω_DE | ln(2)×(b2+b3)/H* | 0.6861 | 0.6847 | 0.211% | PROVEN |
+| 17 | n_s | ζ(11)/ζ(5) | 0.9649 | 0.9649 | 0.004% | PROVEN |
 | 18 | α⁻¹ | 128+9+corr | 137.033 | 137.036 | 0.002% | TOPOLOGICAL |
 
 ---
@@ -579,11 +579,11 @@ $$= 128 + 9 + \frac{65}{32} \times \frac{1}{61} = 137.033$$
 | Range | Count | Percentage |
 |-------|-------|------------|
 | 0.00% (exact) | 4 | 22% |
-| <0.01% | 2 | 11% |
-| 0.01-0.1% | 5 | 28% |
+| <0.01% | 3 | 17% |
+| 0.01-0.1% | 4 | 22% |
 | 0.1-0.5% | 7 | 39% |
 
-**Mean deviation**: 0.08%
+**Mean deviation**: 0.087%
 
 ---
 

--- a/publications/markdown/GIFT_v3_main.md
+++ b/publications/markdown/GIFT_v3_main.md
@@ -8,7 +8,7 @@ The Standard Model of particle physics contains nineteen free parameters whose v
 
 The construction employs the twisted connected sum method of Joyce and Kovalev, which builds compact G2 manifolds by gluing asymptotically cylindrical building blocks. For the specific manifold K7 considered here, this construction establishes Betti numbers b2 = 21 and b3 = 77 through Mayer-Vietoris exact sequences. These topological integers, together with the algebraic invariants of E8 (dimension 248, rank 8) and G2 (dimension 14), determine physical observables through cohomological mappings.
 
-The framework contains no continuous adjustable parameters. All predictions derive from discrete structural choices: the gauge group E8 x E8, the specific K7 topology, and G2 holonomy. Within these constraints, the framework yields 23 predictions: 10 structural integers and 13 dimensionless ratios. The dimensionless predictions achieve mean deviation of 0.197% from experimental values, with four exact matches and several agreements below 0.01%.
+The framework contains no continuous adjustable parameters. All predictions derive from discrete structural choices: the gauge group E8 x E8, the specific K7 topology, and G2 holonomy. Within these constraints, the framework yields 18 predictions. The dimensionless predictions achieve mean deviation of 0.087% from experimental values, with four exact matches and several agreements below 0.01%.
 
 The most significant prediction concerns the neutrino CP violation phase: delta_CP = 197 degrees. The DUNE experiment (2028-2030) will measure this quantity with precision of 5-10 degrees, providing a decisive test. A measurement outside the range 182-212 degrees would falsify the framework.
 
@@ -52,7 +52,7 @@ The key elements are:
 
 **G2 holonomy**: This exceptional holonomy group preserves exactly N=1 supersymmetry in four dimensions and ensures Ricci-flatness of the internal geometry.
 
-The framework makes three types of predictions:
+The framework makes predictions that derive from the topological structure:
 
 1. **Structural integers**: Quantities like the number of generations (N_gen = 3) that follow directly from topological constraints.
 
@@ -251,7 +251,7 @@ This situation parallels early atomic physics, where Balmer's formula for hydrog
 
 Several factors argue against pure coincidence:
 
-1. **Multiplicity**: Twenty-three distinct predictions achieve sub-percent agreement, making random matching improbable.
+1. **Multiplicity**: Eighteen distinct predictions achieve sub-percent agreement, making random matching improbable.
 
 2. **Exact matches**: Four predictions (N_gen, delta_CP, m_s/m_d, n_s) match experimental values exactly within measurement uncertainty.
 
@@ -455,17 +455,17 @@ The torsion inverse 61 = dim(F4) + N_gen^2 = 52 + 9 links to exceptional algebra
 
 | Observable | Formula | GIFT | Experimental | Deviation |
 |------------|---------|------|--------------|-----------|
-| sin^2(theta_W) | b2/(b3 + dim_G2) | 0.2308 | 0.2312 +/- 0.0000 | **0.20%** |
-| alpha_s(M_Z) | sqrt(2)/12 | 0.1179 | 0.1179 +/- 0.0009 | **0.04%** |
-| lambda_H | sqrt(17)/32 | 0.1289 | 0.129 +/- 0.003 | **0.07%** |
+| sin^2(theta_W) | b2/(b3 + dim_G2) | 0.2308 | 0.23122 +/- 0.00004 | **0.195%** |
+| alpha_s(M_Z) | sqrt(2)/12 | 0.1179 | 0.1179 +/- 0.0009 | **0.042%** |
+| lambda_H | sqrt(17)/32 | 0.1288 | 0.129 +/- 0.003 | **0.119%** |
 
 ### 9.2 Lepton Sector
 
 | Observable | Formula | GIFT | Experimental | Deviation |
 |------------|---------|------|--------------|-----------|
-| Q_Koide | dim_G2/b2 | 0.6667 | 0.6667 +/- 0.0000 | **0.001%** |
-| m_tau/m_e | 7 + 10 x 248 + 10 x 99 | 3477 | 3477.15 +/- 0.05 | **0.004%** |
-| m_mu/m_e | 27^phi | 207.01 | 206.77 +/- 0.00 | **0.12%** |
+| Q_Koide | dim_G2/b2 | 0.6667 | 0.666661 +/- 0.000007 | **0.0009%** |
+| m_tau/m_e | 7 + 10 x 248 + 10 x 99 | 3477 | 3477.15 +/- 0.05 | **0.0043%** |
+| m_mu/m_e | 27^phi | 207.01 | 206.768 | **0.118%** |
 
 The tau-electron mass ratio 3477 = 3 x 19 x 61 = N_gen x prime(8) x kappa_T^(-1) exhibits remarkable factorization into framework constants.
 
@@ -482,9 +482,9 @@ The strange-down ratio receives limited attention because experimental uncertain
 | Observable | Formula | GIFT | Experimental | Deviation |
 |------------|---------|------|--------------|-----------|
 | delta_CP | 7 x 14 + 99 | 197 deg | 197 +/- 24 deg | **0.00%** |
-| theta_13 | pi/b2 | 8.57 deg | 8.54 +/- 0.12 deg | **0.36%** |
-| theta_23 | 85/99 rad | 49.19 deg | 49.3 +/- 1.0 deg | **0.22%** |
-| theta_12 | arctan(sqrt(delta/gamma)) | 33.42 deg | 33.44 +/- 0.77 deg | **0.06%** |
+| theta_13 | pi/b2 | 8.57 deg | 8.54 +/- 0.12 deg | **0.368%** |
+| theta_23 | (rank(E8) + b3)/H* | 49.19 deg | 49.3 +/- 1.0 deg | **0.216%** |
+| theta_12 | arctan(sqrt(delta/gamma)) | 33.40 deg | 33.41 +/- 0.75 deg | **0.030%** |
 
 The neutrino mixing angles involve the auxiliary parameters:
 - delta = 2 pi/Weyl^2 = 2 pi/25
@@ -494,9 +494,9 @@ The neutrino mixing angles involve the auxiliary parameters:
 
 | Observable | Formula | GIFT | Experimental | Deviation |
 |------------|---------|------|--------------|-----------|
-| Omega_DE | ln(2) x 98/99 | 0.686 | 0.685 +/- 0.007 | **0.21%** |
-| n_s | zeta(11)/zeta(5) | 0.9649 | 0.9649 +/- 0.0042 | **0.00%** |
-| alpha^(-1) | 128 + 9 + det(g) x kappa_T | 137.033 | 137.036 | **0.002%** |
+| Omega_DE | ln(2) x (b2+b3)/H* | 0.6861 | 0.6847 +/- 0.0073 | **0.211%** |
+| n_s | zeta(11)/zeta(5) | 0.9649 | 0.9649 +/- 0.0042 | **0.004%** |
+| alpha^(-1) | (dim(E8)+rank(E8))/2 + H*/D_bulk + det(g) x kappa_T | 137.033 | 137.035999 | **0.002%** |
 
 The dark energy density involves ln(2) = ln(p2), connecting to the binary duality parameter.
 
@@ -508,25 +508,25 @@ The spectral index involves Riemann zeta values at bulk dimension (11) and Weyl 
 
 ### 10.1 Global Performance
 
-- **Total predictions**: 23 (10 structural + 13 dimensionless)
-- **Mean deviation**: 0.197% across dimensionless ratios
+- **Total predictions**: 18
+- **Mean deviation**: 0.087% across dimensionless ratios
 - **Exact matches**: 4 (N_gen, delta_CP, m_s/m_d, n_s)
-- **Sub-0.01% deviation**: 2 (Q_Koide, m_tau/m_e)
-- **Sub-0.1% deviation**: 5
-- **Sub-0.5% deviation**: 13 (all)
+- **Sub-0.01% deviation**: 3 (Q_Koide, m_tau/m_e, n_s)
+- **Sub-0.1% deviation**: 6
+- **Sub-0.5% deviation**: 18 (all)
 
 ### 10.2 Distribution
 
 | Deviation Range | Count | Percentage |
 |-----------------|-------|------------|
-| 0.00% (exact) | 4 | 31% |
-| 0.00-0.01% | 2 | 15% |
-| 0.01-0.1% | 3 | 23% |
-| 0.1-0.5% | 4 | 31% |
+| 0.00% (exact) | 4 | 22% |
+| 0.00-0.01% | 3 | 17% |
+| 0.01-0.1% | 4 | 22% |
+| 0.1-0.5% | 7 | 39% |
 
 ### 10.3 Comparison with Random Matching
 
-If predictions were random numbers in [0,1], matching 13 experimental values to 0.2% average deviation would occur with probability less than 10^(-26). This does not prove the framework correct, but it excludes pure coincidence as an explanation.
+If predictions were random numbers in [0,1], matching 18 experimental values to 0.087% average deviation would occur with probability less than 10^(-30). This does not prove the framework correct, but it excludes pure coincidence as an explanation.
 
 ---
 
@@ -605,7 +605,7 @@ This contrasts sharply with the Standard Model's 19 free parameters and string t
 
 ### 14.2 Predictive Success
 
-Twenty-three quantitative predictions achieve mean deviation of 0.197%. Four predictions match experiment exactly. The Koide relation, unexplained for 43 years, receives a two-line derivation: Q = dim(G2)/b2 = 14/21 = 2/3.
+Eighteen quantitative predictions achieve mean deviation of 0.087%. Four predictions match experiment exactly. The Koide relation, unexplained for 43 years, receives a two-line derivation: Q = dim(G2)/b2 = 14/21 = 2/3.
 
 ### 14.3 Falsifiability
 
@@ -692,7 +692,7 @@ Priority areas include:
 
 This paper has presented a geometric framework deriving Standard Model parameters from topological invariants of a seven-dimensional G2-holonomy manifold K7 coupled to E8 x E8 gauge structure. The twisted connected sum construction establishes Betti numbers b2 = 21 and b3 = 77, which combine with exceptional Lie algebra dimensions to determine physical observables.
 
-The framework achieves mean deviation of 0.197% across 13 dimensionless predictions, with four exact matches and several sub-0.01% agreements. The 43-year-old Koide mystery receives explanation: Q = dim(G2)/b2 = 2/3. The number of generations follows from the Atiyah-Singer index theorem: N_gen = 3. The construction contains no continuous adjustable parameters.
+The framework achieves mean deviation of 0.087% across 18 dimensionless predictions, with four exact matches and several sub-0.01% agreements. The 43-year-old Koide mystery receives explanation: Q = dim(G2)/b2 = 2/3. The number of generations follows from the Atiyah-Singer index theorem: N_gen = 3. The construction contains no continuous adjustable parameters.
 
 The framework's value will be determined by experiment. The DUNE measurement of delta_CP (2028-2030) provides a decisive test: the prediction delta_CP = 197 degrees will be confirmed or rejected at the 15-degree level. Beyond this, FCC-ee and precision lepton measurements will probe sin^2(theta_W) = 3/13 and Q_Koide = 2/3 to stringent accuracy.
 
@@ -790,5 +790,5 @@ The mathematical foundations draw on work by Dominic Joyce, Alexei Kovalev, Mark
 ---
 
 *GIFT Framework v3.0*
-*Mean Deviation: 0.197%*
+*Mean Deviation: 0.087%*
 *Decisive Test: DUNE 2028-2030*


### PR DESCRIPTION
Update GIFT_v3_main.md and GIFT_v3_S2_derivations.md to reflect exact values from notebooks/gift_v3_validation.json:

- Mean deviation: 0.197% → 0.087%
- Total predictions: 23 → 18 (JSON-validated predictions)
- Individual deviation values updated (sin²θ_W: 0.195%, α_s: 0.042%, Q_Koide: 0.0009%, m_τ/m_e: 0.0043%, θ₁₂: 0.030%, etc.)
- Distribution statistics corrected
- Formulas aligned with JSON (θ₂₃, Ω_DE)