### PR TITLE
Update README, STRUCTURE, and CHANGELOG for v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,44 @@ All notable changes to the GIFT framework are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.1] - 2025-12-11
+
+### Validation Synchronization & Documentation Update
+
+Synchronized publications with latest validation notebook results and added speculative extensions documentation.
+
+#### Changed
+
+**Precision Update (Validation Run 2025-12-11)**
+- Mean deviation: 0.197% → **0.087%** (improved calculation methodology)
+- All 18 dimensionless predictions verified against `notebooks/gift_v3_validation.json`
+- Individual deviation values updated to exact JSON results:
+  - sin²θ_W: 0.195% (was 0.20%)
+  - α_s: 0.042% (was 0.04%)
+  - Q_Koide: 0.0009% (was 0.001%)
+  - m_τ/m_e: 0.0043% (was 0.004%)
+  - θ₁₂: 0.030% (was 0.06%)
+  - λ_H: 0.119% (was 0.07%)
+  - n_s: 0.004% (was 0.00%)
+  - Ω_DE: 0.211% (was 0.21%)
+
+**Documentation Structure**
+- Added `docs/technical/` for speculative extensions:
+  - S3: Torsional dynamics (RG flow, non-zero torsion)
+  - S6: Theoretical extensions (M-theory, QG connections)
+  - S7: Dimensional observables (absolute masses, scale bridge)
+  - GIFT Atlas: Complete constant/relation database
+- README.md updated with new navigation section
+- STRUCTURE.md updated with docs/technical/ layout
+
+#### Files Modified
+- `publications/markdown/GIFT_v3_main.md`: Statistics and deviation values
+- `publications/markdown/GIFT_v3_S2_derivations.md`: All deviation tables
+- `README.md`: Overview metrics, navigation, documentation links
+- `STRUCTURE.md`: Directory layout, version info
+
+---
+
 ## [3.0.0] - 2025-12-09
 
 ### Major Release: Number-Theoretic Structure - 165+ Certified Relations

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # Geometric Information Field Theory v3.0
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-3.0-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-3.0.1-green.svg)](CHANGELOG.md)
 [![Lean 4 Verified](https://img.shields.io/badge/Lean_4-Verified-blue)](https://github.com/gift-framework/core)
 [![Relations](https://img.shields.io/badge/Relations-165+-orange)](https://github.com/gift-framework/core)
+[![Precision](https://img.shields.io/badge/Mean_Deviation-0.087%25-brightgreen)](publications/markdown/GIFT_v3_S2_derivations.md)
 
 A geometric framework deriving Standard Model parameters from topological invariants of E₈×E₈ gauge structure compactified on a G₂-holonomy manifold K₇.
 
@@ -13,7 +14,7 @@ A geometric framework deriving Standard Model parameters from topological invari
 
 | Metric | Value |
 |--------|-------|
-| Precision | 0.197% mean deviation across 39 observables |
+| Precision | **0.087% mean deviation** across 18 dimensionless predictions |
 | Adjustable parameters | Zero (all structurally determined) |
 | Formally verified relations | **165+ proven in Lean 4 + Coq** (zero axioms) |
 | Key exact results | sin²θ_W = 3/13, τ = 3472/891, det(g) = 65/32, Monster = 47×59×71 |
@@ -36,7 +37,7 @@ The dimensional reduction chain: **E₈×E₈ (496D) → AdS₄ × K₇ (11D) �
 
 ### "Show me the numbers"
 
-→ [39 Observables CSV](publications/references/39_observables.csv) Machine-readable data
+→ [18 Dimensionless Predictions](publications/markdown/GIFT_v3_S2_derivations.md) Complete derivations with 0.087% mean deviation
 
 ### "Show me the proofs"
 
@@ -67,6 +68,9 @@ The dimensional reduction chain: **E₈×E₈ (496D) → AdS₄ × K₇ (11D) �
 **"I'm interested in formalization"**
 → [Lean for Physics](docs/LEAN_FOR_PHYSICS.md) - Machine-verified physical relations
 
+**"I want dimensional observables"**
+→ [docs/technical/](docs/technical/) - Speculative extensions for absolute masses, scale bridge, and torsional dynamics
+
 ---
 
 ## Interactive Visualizations
@@ -96,8 +100,15 @@ The dimensional reduction chain: **E₈×E₈ (496D) → AdS₄ × K₇ (11D) �
 | [Yukawa & Mixing](publications/references/yukawa_mixing.md) | CKM/PMNS matrices, Yukawa couplings |
 | [Sequences & Primes](publications/references/sequences_prime_atlas.md) | Fibonacci embedding, Prime Atlas |
 | [Monster & Moonshine](publications/references/monster_moonshine.md) | Monster group, j-invariant |
-| [Dimensional](publications/references/dimensional_observables.md) | Absolute masses (heuristic) |
-| [Extensions](publications/references/theoretical_extensions.md) | M-theory, quantum gravity |
+
+### Speculative Extensions (docs/technical/)
+
+| Document | Content |
+|----------|---------|
+| [S7: Dimensional Observables](docs/technical/S7_dimensional_observables_v30.md) | Absolute masses, scale bridge (speculative) |
+| [S6: Theoretical Extensions](docs/technical/S6_theoretical_extensions_v30.md) | M-theory, quantum gravity connections |
+| [S3: Torsional Dynamics](docs/technical/S3_torsional_dynamics_v30.md) | RG flow, non-zero torsion |
+| [GIFT Atlas](docs/technical/atlas/) | Complete constant/relation database |
 
 ---
 
@@ -111,16 +122,16 @@ The dimensional reduction chain: **E₈×E₈ (496D) → AdS₄ × K₇ (11D) �
 
 ## Key Results
 
-### Precision by Sector
+### Precision by Sector (18 Dimensionless Predictions)
 
-| Sector | Observables | Mean Deviation | Highlight |
+| Sector | Predictions | Mean Deviation | Highlight |
 |--------|-------------|----------------|-----------|
-| Gauge | 3 | 0.06% | α_s = √2/12 |
-| Lepton | 4 | 0.04% | Q_Koide = 2/3 (exact) |
-| CKM | 6 | 0.08% | |
-| Neutrino | 4 | 0.13% | δ_CP = 197° (exact) |
-| Quark ratios | 10 | 0.18% | m_s/m_d = 20 (exact) |
-| Cosmology | 2 | 0.11% | Ω_DE = ln(2) × 98/99 |
+| Electroweak | 3 | 0.12% | sin²θ_W = 3/13 |
+| Lepton | 3 | 0.04% | Q_Koide = 2/3 (0.0009%) |
+| Quark | 1 | 0.00% | m_s/m_d = 20 (exact) |
+| Neutrino | 4 | 0.15% | δ_CP = 197° (exact) |
+| Cosmology | 3 | 0.07% | n_s = ζ(11)/ζ(5) (0.004%) |
+| Structural | 4 | exact | N_gen = 3, τ = 3472/891 |
 
 ### Selected Exact Relations (Lean 4 + Coq Verified)
 
@@ -145,7 +156,7 @@ The dimensional reduction chain: **E₈×E₈ (496D) → AdS₄ × K₇ (11D) �
 | j-invariant | 744 = 3 × 248 = N_gen × dim(E₈) | **PROVEN** |
 | McKay | Coxeter(E₈) = 30 = icosahedron edges | **PROVEN** |
 
-Full list: [39 Observables CSV](publications/references/39_observables.csv) | Proofs: [gift-framework/core](https://github.com/gift-framework/core)
+Full derivations: [S2: Derivations](publications/markdown/GIFT_v3_S2_derivations.md) | Proofs: [gift-framework/core](https://github.com/gift-framework/core)
 
 ---
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -32,7 +32,16 @@ GIFT/
 │   ├── LEAN_FOR_PHYSICS.md         # Guide for formalization
 │   ├── figures/                     # Lean blueprints
 │   ├── legacy/                      # Archived v2.3/v3.0 supplements
-│   └── wip/                         # Work in progress
+│   ├── wip/                         # Work in progress
+│   └── technical/                   # Speculative extensions
+│       ├── S3_torsional_dynamics_v30.md    # RG flow, torsion
+│       ├── S6_theoretical_extensions_v30.md # M-theory, QG
+│       ├── S7_dimensional_observables_v30.md # Absolute masses
+│       ├── JOYCE_FORMALIZATION.md   # Lean formalization of Joyce thm
+│       └── atlas/                   # GIFT constant/relation database
+│           ├── GIFT_ATLAS.yaml      # Source definitions
+│           ├── generate_atlas.py    # Generator script
+│           └── generated/           # Auto-generated docs
 │
 ├── statistical_validation/          # Monte Carlo validation
 │
@@ -54,6 +63,7 @@ GIFT/
 | Formal verification | [gift-framework/core](https://github.com/gift-framework/core) |
 | Technical definitions | `docs/GLOSSARY.md` |
 | Legacy supplements | `docs/legacy/` |
+| Speculative extensions | `docs/technical/` |
 
 ## Core Documents (v3.0)
 
@@ -70,8 +80,15 @@ GIFT/
 | yukawa_mixing.md | CKM/PMNS matrices, Yukawa couplings |
 | sequences_prime_atlas.md | Fibonacci embedding, Prime Atlas |
 | monster_moonshine.md | Monster group, j-invariant connections |
-| dimensional_observables.md | Absolute masses (heuristic) |
-| theoretical_extensions.md | M-theory, quantum gravity |
+
+## Speculative Extensions (docs/technical/)
+
+| Document | Content |
+|----------|---------|
+| S7_dimensional_observables_v30.md | Absolute masses, scale bridge (speculative) |
+| S6_theoretical_extensions_v30.md | M-theory, quantum gravity connections |
+| S3_torsional_dynamics_v30.md | RG flow, non-zero torsion |
+| atlas/ | Complete GIFT constant/relation database |
 
 ## Related Repositories
 
@@ -83,4 +100,4 @@ GIFT/
 
 **Current**: v3.0.0 (2025-12-11)
 **Relations**: 165+ certified
-**Observables**: 18 dimensionless (0.197% mean deviation)
+**Predictions**: 18 dimensionless (**0.087% mean deviation**)


### PR DESCRIPTION
- Update mean deviation: 0.197% → 0.087% (validated)
- Add docs/technical/ section for speculative extensions
- Document S3 (torsional), S6 (extensions), S7 (dimensional)
- Add GIFT Atlas reference
- Update navigation with "dimensional observables" guide
- Add precision badge to README
- Version bump to 3.0.1 in badges and changelog