### PR TITLE
Sync documentation with v3.0 metrics and core v3.0.0

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -14,7 +14,7 @@ Citation formats for the GIFT Framework v3.0.
   url     = {https://github.com/gift-framework/GIFT},
   version = {3.0.0},
   license = {MIT},
-  note    = {18 dimensionless observables, 0.197\% precision, 165+ certified relations}
+  note    = {18 dimensionless predictions, 0.087\% mean deviation, 165+ certified relations}
 }
 ```
 
@@ -41,7 +41,7 @@ de La Fournière, Brieuc. "GIFT Framework v3.0: Geometric Information Field Theo
   title  = {Geometric Information Field Theory v3.0: Topological Determination of Standard Model Parameters},
   author = {de La Fournière, Brieuc},
   year   = {2025},
-  note   = {Mean deviation 0.197\% across 18 dimensionless observables, zero continuous adjustable parameters, 165+ proven exact relations},
+  note   = {Mean deviation 0.087\% across 18 dimensionless predictions, zero continuous adjustable parameters, 165+ proven exact relations},
   url    = {https://github.com/gift-framework/GIFT}
 }
 ```
@@ -134,13 +134,13 @@ de La Fournière, Brieuc. "GIFT Framework v3.0: Geometric Information Field Theo
 ## Formal Verification
 
 ```bibtex
-@software{gift_core_v20,
+@software{gift_core_v30,
   title   = {GIFT Core: Formal Verification in Lean 4 + Coq},
   author  = {de La Fournière, Brieuc},
   year    = {2025},
   url     = {https://github.com/gift-framework/core},
-  version = {2.0.0},
-  note    = {165+ relations verified, zero axioms, K₇ metric pipeline}
+  version = {3.0.0},
+  note    = {165+ relations verified, zero axioms, K₇ metric pipeline, Joyce existence theorem}
 }
 ```
 

--- a/docs/EXPERIMENTAL_VALIDATION.md
+++ b/docs/EXPERIMENTAL_VALIDATION.md
@@ -4,7 +4,7 @@ Current experimental status of GIFT predictions, precision comparisons, and time
 
 ## Overview
 
-The GIFT framework v3.0 makes 23 predictions (10 structural + 13 dimensionless ratios) with mean experimental deviation of 0.197%. This document tracks:
+The GIFT framework v3.0 makes 18 dimensionless predictions with mean experimental deviation of 0.087%. This document tracks:
 - Current experimental status for each prediction
 - Precision evolution over time
 - Planned experiments and timelines
@@ -36,7 +36,7 @@ The GIFT framework v3.0 makes 23 predictions (10 structural + 13 dimensionless r
 - Most CKM matrix elements: mean 0.11%
 - Most quark mass ratios
 
-**Overall**: 39 observables (27 dimensionless + 12 dimensional), mean deviation 0.197%
+**Overall**: 18 dimensionless predictions, mean deviation 0.087% (v3.0 core set)
 
 ### By Physics Sector
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -32,7 +32,7 @@ GIFT is a speculative theoretical framework presenting testable predictions. The
 
 The framework is evaluated based on:
 - Mathematical rigor of derivations
-- Precision of experimental agreement (currently 0.197% mean deviation across 39 observables)
+- Precision of experimental agreement (currently 0.087% mean deviation across 18 dimensionless predictions)
 - Falsifiability (clear criteria in Supplement S5)
 - Reproducibility (computational notebook available)
 
@@ -41,7 +41,7 @@ The framework is evaluated based on:
 **Standard Model**: 19 free parameters
 **GIFT v3.0**: Zero continuous adjustable parameters
 
-All quantities derive from fixed topological structure (E₈×E₈ gauge group, K₇ manifold with G₂ holonomy). The framework achieves "structural determination" where discrete mathematical choices uniquely determine all 39 observables.
+All quantities derive from fixed topological structure (E₈×E₈ gauge group, K₇ manifold with G₂ holonomy). The framework achieves "structural determination" where discrete mathematical choices uniquely determine all predictions.
 
 ### Can GIFT be falsified?
 
@@ -115,25 +115,21 @@ See Supplement S1 for complete mathematical details.
 
 ### What observables does GIFT predict?
 
-**39 observables (27 dimensionless + 12 dimensional)**:
+**18 dimensionless predictions** (v3.0 core set):
 
-*Dimensionless (27):*
 - 3 gauge couplings (α, sin²θ_W, α_s)
 - 1 generation number (N_gen = 3)
 - 4 neutrino mixing angles (θ₁₂, θ₁₃, θ₂₃, δ_CP)
-- 6 quark mass ratios
-- 3 lepton mass ratios
-- 4 CKM matrix elements
-- 1 Koide parameter
+- 2 lepton mass ratios (m_τ/m_e, m_μ/m_e)
+- 1 quark mass ratio (m_s/m_d)
+- 1 Koide parameter (Q = 2/3)
 - 2 cosmological parameters (Ω_DE, n_s)
-- Additional structural constants
+- 2 electroweak parameters (λ_H, hierarchy)
+- 2 topological constants (κ_T, det(g))
 
-*Dimensional (12):*
-- 3 electroweak scale parameters (v_EW, M_W, M_Z)
-- 6 quark masses (m_u through m_t)
-- 3 lepton masses
+Mean deviation from experiment: **0.087%**
 
-Mean deviation from experiment: 0.197%
+*Note: Extended dimensional predictions (masses, electroweak scale) are documented in legacy files (v2.3) with 0.197% mean deviation across 39 observables.*
 
 ### What about dimensional parameters like masses?
 
@@ -165,7 +161,7 @@ The dimensional predictions (status: THEORETICAL/DERIVED) are less rigorous than
 - Gauge couplings: mean 0.03%
 - CKM matrix: mean 0.11%
 
-**Overall**: Mean 0.197% across all 39 observables
+**Overall**: Mean 0.087% across 18 dimensionless predictions (v3.0)
 
 See Supplement S5 for detailed statistical analysis.
 
@@ -179,7 +175,7 @@ Subjectively, several stand out:
 
 **N_gen = 3**: Explains why three generations exist as topological necessity, not accident.
 
-**Zero-parameter paradigm**: All 39 observables derived from fixed topological structure with no continuous adjustable parameters.
+**Zero-parameter paradigm**: All predictions derived from fixed topological structure with no continuous adjustable parameters.
 
 ### What are the biggest tensions?
 

--- a/docs/INFO_GEO_FOR_PHYSICISTS.md
+++ b/docs/INFO_GEO_FOR_PHYSICISTS.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-The Geometric Information Field Theory (GIFT) framework proposes that Standard Model parameters are not free constants requiring experimental determination, but rather topological invariants of an underlying geometric structure. Specifically, the framework derives 39 observables from the cohomology of a 7-dimensional G₂ holonomy manifold K₇ coupled to E₈×E₈ gauge architecture. This document presents the conceptual structure for theoretical physicists, focusing on how topology might eliminate the need for adjustable parameters.
+The Geometric Information Field Theory (GIFT) framework proposes that Standard Model parameters are not free constants requiring experimental determination, but rather topological invariants of an underlying geometric structure. Specifically, the framework derives 18 dimensionless predictions from the cohomology of a 7-dimensional G₂ holonomy manifold K₇ coupled to E₈×E₈ gauge architecture. This document presents the conceptual structure for theoretical physicists, focusing on how topology might eliminate the need for adjustable parameters.
 
 ## 1. The Parameter Problem
 
@@ -76,7 +76,7 @@ The empirical Koide formula (m_e + m_μ + m_τ)/(√m_e + √m_μ + √m_τ)² =
 
 ### 3.3 What is Claimed
 
-The framework produces 39 observables spanning gauge couplings, neutrino mixing, lepton mass ratios, quark mass ratios, CKM matrix elements, electroweak scale parameters, and cosmological observables. The mean deviation from experimental values is 0.197%.
+The framework produces 18 dimensionless predictions spanning gauge couplings, neutrino mixing, lepton mass ratios, quark mass ratios, and cosmological observables. The mean deviation from experimental values is 0.087%.
 
 All 165+ relations have been formally verified in both Lean 4 and Coq proof assistants, using only standard axioms (propext, Quot.sound in Lean; standard Coq axioms) with zero domain-specific axioms.
 
@@ -115,7 +115,7 @@ The framework makes specific predictions testable by near-term experiments:
 
 The GIFT framework explores whether Standard Model parameters might be topological invariants rather than free constants. The specific proposal involves E₈×E₈ gauge structure, G₂ holonomy on a 7-manifold K₇ with Betti numbers b₂ = 21 and b₃ = 77, and controlled torsion providing dynamics.
 
-The resulting 39 predictions match experiment to 0.197% mean precision. Whether this reflects fundamental physics or an elaborate coincidence will be determined by experiments, particularly DUNE's measurement of the CP violation phase δ_CP in the coming years.
+The resulting 18 dimensionless predictions match experiment to 0.087% mean precision. Whether this reflects fundamental physics or an elaborate coincidence will be determined by experiments, particularly DUNE's measurement of the CP violation phase δ_CP in the coming years.
 
 The framework's value, independent of its physical correctness, lies in demonstrating that geometric principles can substantially constrain particle physics parameters. It provides a concrete example of how topology might replace tuning.
 

--- a/docs/figures/gift_blueprint.html
+++ b/docs/figures/gift_blueprint.html
@@ -358,7 +358,7 @@
                 <div class="empty-state">
                     <div class="empty-state-icon">&#9679;</div>
                     <div>Click a node to view details</div>
-                    <div style="margin-top: 10px; font-size: 0.7rem;">165+ relations from gift-framework/core v2.0</div>
+                    <div style="margin-top: 10px; font-size: 0.7rem;">165+ relations from gift-framework/core v3.0</div>
                 </div>
             </div>
         </aside>


### PR DESCRIPTION
Update active documentation files to reflect GIFT v3.0 metrics:
- 18 dimensionless predictions (was 39 observables)
- 0.087% mean deviation (was 0.197%)
- gift-framework/core v3.0.0 (was v2.0.0)

Files updated:
- CITATION.md: precision and core version
- docs/FAQ.md: predictions count and deviation
- docs/INFO_GEO_FOR_PHYSICISTS.md: observables count and deviation
- docs/EXPERIMENTAL_VALIDATION.md: overview metrics
- docs/figures/gift_blueprint.html: core version reference

Legacy files (docs/legacy/, statistical_validation/) retain historical values as they document specific validation runs.