### PR TITLE
docs: sync with core v3.1.4 — 165+ → 180+ relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to the GIFT framework are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2025-12-17
+
+### Core Sync — 180+ Relations
+
+Synchronized documentation with [gift-framework/core v3.1.4](https://github.com/gift-framework/core).
+
+#### Changed
+
+**Relation Count**: 165+ → **180+**
+- Core added 15+ new relations in v3.1.1 through v3.1.4
+- Lagrange identity for 7D cross product now PROVEN (was axiom)
+- AnalyticalMetric.lean formalizes exact G₂ metric
+
+**Files Updated**:
+- `README.md`, `STRUCTURE.md`, `CITATION.md`
+- `publications/markdown/GIFT_v3_main.md`
+- `publications/markdown/GIFT_v3_S1_foundations.md`
+- `publications/README.md`
+- `docs/INFO_GEO_FOR_PHYSICISTS.md`
+- `docs/EXPERIMENTAL_VALIDATION.md`
+- `docs/GIFT_v3.1_LITERATURE_ANALYSIS.md`
+
+---
+
 ## [3.1.0] - 2025-12-17
 
 ### Analytical G₂ Metric — Exact Solution

--- a/CITATION.md
+++ b/CITATION.md
@@ -14,7 +14,7 @@ Citation formats for the GIFT Framework v3.0.
   url     = {https://github.com/gift-framework/GIFT},
   version = {3.0.0},
   license = {MIT},
-  note    = {18 dimensionless predictions, 0.087\% mean deviation, 165+ certified relations}
+  note    = {18 dimensionless predictions, 0.087\% mean deviation, 180+ certified relations}
 }
 ```
 
@@ -41,7 +41,7 @@ de La Fournière, Brieuc. "GIFT Framework v3.0: Geometric Information Field Theo
   title  = {Geometric Information Field Theory v3.0: Topological Determination of Standard Model Parameters},
   author = {de La Fournière, Brieuc},
   year   = {2025},
-  note   = {Mean deviation 0.087\% across 18 dimensionless predictions, zero continuous adjustable parameters, 165+ proven exact relations},
+  note   = {Mean deviation 0.087\% across 18 dimensionless predictions, zero continuous adjustable parameters, 180+ proven exact relations},
   url    = {https://github.com/gift-framework/GIFT}
 }
 ```
@@ -140,7 +140,7 @@ de La Fournière, Brieuc. "GIFT Framework v3.0: Geometric Information Field Theo
   year    = {2025},
   url     = {https://github.com/gift-framework/core},
   version = {3.0.0},
-  note    = {165+ relations verified, zero axioms, K₇ metric pipeline, Joyce existence theorem}
+  note    = {180+ relations verified, zero axioms, K₇ metric pipeline, Joyce existence theorem}
 }
 ```
 
@@ -159,6 +159,7 @@ de La Fournière, Brieuc. "GIFT Framework v3.0: Geometric Information Field Theo
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 3.1.0 | 2025-12-17 | Analytical G₂ metric, 180+ certified relations |
 | 3.0.0 | 2025-12-09 | Major release: 165+ certified relations, Fibonacci/Monster/McKay |
 | 2.3.x | 2025-12 | Dual Lean 4 + Coq verification |
 | 2.2.0 | 2025-11-27 | Zero-parameter paradigm |
@@ -192,4 +193,4 @@ MIT License - See [LICENSE](LICENSE)
 
 ---
 
-**Version**: 3.0.0 (2025-12-11)
+**Version**: 3.1.1 (2025-12-17)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Geometric Information Field Theory v3.1
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-3.1.0-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-3.1.1-green.svg)](CHANGELOG.md)
 [![Lean 4 + Coq](https://img.shields.io/badge/Formally_Verified-Lean_4_+_Coq-blue)](https://github.com/gift-framework/core)
 
 **Standard Model parameters from pure geometry** — E₈×E₈ on G₂-holonomy manifold K₇, zero adjustable parameters.
@@ -14,7 +14,7 @@
 |---|---|
 | **Precision** | 0.087% mean deviation across 18 dimensionless predictions |
 | **Parameters** | Zero adjustable (all structurally determined) |
-| **Verified** | 165+ relations proven in Lean 4 + Coq (zero axioms) |
+| **Verified** | 180+ relations proven in Lean 4 + Coq (zero axioms) |
 | **Exact results** | sin²θ_W = 3/13 · τ = 3472/891 · det(g) = 65/32 · Monster = 47×59×71 |
 
 **Dimensional reduction:** E₈×E₈ (496D) → AdS₄ × K₇ (11D) → Standard Model (4D)

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -99,7 +99,7 @@ GIFT/
 
 ## Version
 
-**Current**: v3.1.0 (2025-12-17)
-**Relations**: 165+ certified
+**Current**: v3.1.1 (2025-12-17)
+**Relations**: 180+ certified
 **Predictions**: 18 dimensionless (**0.087% mean deviation**)
 **Key Result**: Analytical G₂ metric with T = 0 exactly

--- a/docs/EXPERIMENTAL_VALIDATION.md
+++ b/docs/EXPERIMENTAL_VALIDATION.md
@@ -351,7 +351,7 @@ No sector shows systematic problems. All perform well.
 - Genuine predictive power
 - Complete elimination of free parameters
 - All quantities structurally determined
-- 165+ relations formally verified in Lean 4 + Coq
+- 180+ relations formally verified in Lean 4 + Coq
 
 **Other unification attempts**:
 - SU(5) GUT: Incorrect sin²θ_W prediction (~0.20 vs 0.23)

--- a/docs/GIFT_v3.1_LITERATURE_ANALYSIS.md
+++ b/docs/GIFT_v3.1_LITERATURE_ANALYSIS.md
@@ -132,7 +132,7 @@ GIFT s'inscrit dans **trois courants de recherche actifs** avec des publications
 | **Octonions** | Qualitatif (Furey, Baez) | + Quantitatif (b₂ = C(7,2)) |
 | **G₂ manifolds** | Construction (Nordström) | + Sélection physique |
 | **Prédictions** | Aucune numérique | 18 dimensionless, 0.087% |
-| **Vérification** | Prose mathématique | Lean 4 + Coq (175+ relations) |
+| **Vérification** | Prose mathématique | Lean 4 + Coq (180+ relations) |
 
 ### Le "gap" que GIFT remplit
 

--- a/docs/INFO_GEO_FOR_PHYSICISTS.md
+++ b/docs/INFO_GEO_FOR_PHYSICISTS.md
@@ -78,7 +78,7 @@ The empirical Koide formula (m_e + m_μ + m_τ)/(√m_e + √m_μ + √m_τ)² =
 
 The framework produces 18 dimensionless predictions spanning gauge couplings, neutrino mixing, lepton mass ratios, quark mass ratios, and cosmological observables. The mean deviation from experimental values is 0.087%.
 
-All 165+ relations have been formally verified in both Lean 4 and Coq proof assistants, using only standard axioms (propext, Quot.sound in Lean; standard Coq axioms) with zero domain-specific axioms.
+All 180+ relations have been formally verified in both Lean 4 and Coq proof assistants, using only standard axioms (propext, Quot.sound in Lean; standard Coq axioms) with zero domain-specific axioms.
 
 ### 3.4 What is Not Claimed
 

--- a/publications/README.md
+++ b/publications/README.md
@@ -79,7 +79,7 @@ All 18 dimensionless derivations with complete proofs.
 
 ## Formal Verification
 
-**165+ relations verified** in Lean 4 + Coq (dual verification).
+**180+ relations verified** in Lean 4 + Coq (dual verification).
 
 See [gift-framework/core](https://github.com/gift-framework/core) for proofs.
 

--- a/publications/markdown/GIFT_v3_S1_foundations.md
+++ b/publications/markdown/GIFT_v3_S1_foundations.md
@@ -7,7 +7,7 @@
 *Complete mathematical foundations for GIFT v3.1, merging E₈ architecture with K₇ manifold construction.*
 
 **Version**: 3.1
-**Lean Verification**: 165+ relations, 0 sorry
+**Lean Verification**: 180+ relations, 0 sorry
 
 ---
 

--- a/publications/markdown/GIFT_v3_main.md
+++ b/publications/markdown/GIFT_v3_main.md
@@ -673,7 +673,7 @@ Unlike many approaches to fundamental physics, GIFT makes sharp, testable predic
 
 ### 14.4 Mathematical Rigor
 
-The topological foundations rest on established mathematics. The TCS construction follows Joyce, Kovalev, and collaborators. The index theorem derivation of N_gen = 3 is standard. Over 165 relations have been verified in Lean 4, providing machine-checked confirmation of algebraic claims.
+The topological foundations rest on established mathematics. The TCS construction follows Joyce, Kovalev, and collaborators. The index theorem derivation of N_gen = 3 is standard. Over 180 relations have been verified in Lean 4, providing machine-checked confirmation of algebraic claims.
 
 ---
 


### PR DESCRIPTION
Synchronized documentation with gift-framework/core v3.1.4:
- Updated relation count from 165+ to 180+
- Core added Lagrange identity proof (was axiom)
- Core added AnalyticalMetric.lean formalization
- Bumped version to 3.1.1 across all docs