### PR TITLE
docs: complete sync — add S3 to all READMEs, update versions

### DIFF
--- a/docs/LEAN_FOR_PHYSICS.md
+++ b/docs/LEAN_FOR_PHYSICS.md
@@ -2,7 +2,7 @@
 
 ## Abstract
 
-This document describes the Lean 4 and Coq formalization of the GIFT framework, which derives Standard Model parameters from topological invariants. The formalization verifies 165+ exact relations connecting geometric data (Betti numbers, Lie algebra dimensions, cohomological invariants) to physical observables (mixing angles, mass ratios, coupling constants). The verification uses only standard axioms with zero domain-specific assumptions, demonstrating that machine-checked proofs can provide audit trails for theoretical physics claims.
+This document describes the Lean 4 and Coq formalization of the GIFT framework, which derives Standard Model parameters from topological invariants. The formalization verifies 180+ exact relations connecting geometric data (Betti numbers, Lie algebra dimensions, cohomological invariants) to physical observables (mixing angles, mass ratios, coupling constants). The verification uses only standard axioms with zero domain-specific assumptions, demonstrating that machine-checked proofs can provide audit trails for theoretical physics claims.
 
 ## 1. The Verification Challenge
 
@@ -36,7 +36,7 @@ The GIFT formalization focuses on the first three categories: algebraic data (E�
 
 ### 2.1 Scope
 
-The formalization covers 165+ exact relations verified in both Lean 4 (with Mathlib 4.14+) and Coq (version 8.18). Dual verification in independent proof assistants provides additional confidence: a bug in one system would not reproduce in the other.
+The formalization covers 180+ exact relations verified in both Lean 4 (with Mathlib 4.14+) and Coq (version 8.18). Dual verification in independent proof assistants provides additional confidence: a bug in one system would not reproduce in the other.
 
 **Critical property**: The proofs use zero domain-specific axioms. The only axioms employed are:
 - Lean: `propext` (propositional extensionality), `Quot.sound` (quotient soundness) - both standard
@@ -52,7 +52,7 @@ The Lean formalization is organized as follows:
 |--------|---------|----------|
 | `GIFT.Algebra` | E₈ definition, dim = 248, rank = 8 | Core algebraic structures |
 | `GIFT.Topology` | K₇ Betti numbers b₂ = 21, b₃ = 77 | Topological invariants |
-| `GIFT.Relations` | 165+ physical relations | Main results |
+| `GIFT.Relations` | 180+ physical relations | Main results |
 | `GIFT.Relations.GaugeSector` | sin²θ_W = 3/13, α_s denominator | Gauge coupling relations |
 | `GIFT.Relations.NeutrinoSector` | δ_CP = 197°, mixing angles | Neutrino observables |
 | `GIFT.Relations.LeptonSector` | Q_Koide = 2/3, mass ratios | Lepton relations |
@@ -140,7 +140,7 @@ The formalization does not establish:
 
 | Metric | Value |
 |--------|-------|
-| Total relations verified | 165+ |
+| Total relations verified | 180+ |
 | Proof assistants | 2 (Lean 4, Coq) |
 | Domain axioms | 0 |
 | Incomplete proofs | 0 |
@@ -227,7 +227,7 @@ The repository maintains CI pipelines that rebuild all proofs on each commit. Gr
 
 ## 6. Summary
 
-The GIFT formalization demonstrates that machine-verified proofs can apply to theoretical physics. The 165+ relations connecting E₈×E₈ and K₇ topology to Standard Model observables have been proven in both Lean 4 and Coq, using zero domain-specific axioms.
+The GIFT formalization demonstrates that machine-verified proofs can apply to theoretical physics. The 180+ relations connecting E₈×E₈ and K₇ topology to Standard Model observables have been proven in both Lean 4 and Coq, using zero domain-specific axioms.
 
 This establishes internal consistency: given the stated topological inputs, the physical relations follow by pure computation. Whether the inputs describe physical reality remains an empirical question, to be addressed by experiments like DUNE's measurement of δ_CP.
 
@@ -243,4 +243,4 @@ The methodological contribution is independent of GIFT's physical correctness. F
 
 ---
 
-*GIFT Framework v3.0 - Formal Verification Documentation*
+*GIFT Framework v3.1 - Formal Verification Documentation*

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # GIFT Framework - Documentation
 
-Supporting documentation for the GIFT Framework v3.0.
+Supporting documentation for the GIFT Framework v3.1.
 
 ## Contents
 
@@ -25,6 +25,7 @@ Static visualizations are available in the [`figures/`](figures/) directory:
 - [Main Paper](../publications/markdown/GIFT_v3_main.md) - Complete theoretical framework
 - [S1: Foundations](../publications/markdown/GIFT_v3_S1_foundations.md) - E₈, G₂, K₇ mathematical construction
 - [S2: Derivations](../publications/markdown/GIFT_v3_S2_derivations.md) - 18 dimensionless derivations
+- [S3: Dynamics](../publications/markdown/GIFT_v3_S3_dynamics.md) - RG flow, torsional dynamics
 - [Observables CSV](../publications/references/39_observables.csv) - Machine-readable data
 
 ## Exploratory References
@@ -41,4 +42,4 @@ Historical supplements (v2.3/v3.0 drafts) archived in [`legacy/`](legacy/).
 
 ---
 
-Part of GIFT Framework v3.0 - MIT License
+Part of GIFT Framework v3.1 - MIT License

--- a/docs/figures/README.md
+++ b/docs/figures/README.md
@@ -19,4 +19,4 @@ For interactive visualizations, see Binder: https://mybinder.org/v2/gh/gift-fram
 
 ---
 
-Part of GIFT Framework v2.3
+Part of GIFT Framework v3.1

--- a/docs/technical/JOYCE_FORMALIZATION.md
+++ b/docs/technical/JOYCE_FORMALIZATION.md
@@ -626,7 +626,7 @@ Certified Constants (Algebra.lean)
 ├── b2 = 21, b3 = 77, H_star = 99
 ├── dim_G2 = 14, dim_E8 = 248
 ├── det_g = 65/32, kappa_T = 1/61
-└── ...165+ relations
+└── ...180+ relations
 
         ↓ (used by)
 

--- a/docs/technical/S6_theoretical_extensions_v30.md
+++ b/docs/technical/S6_theoretical_extensions_v30.md
@@ -404,7 +404,7 @@ The GIFT framework opens several speculative directions:
 3. **Number theory**: Fibonacci-Lucas-Mersenne patterns (status unclear)
 4. **Speculative**: Emergence of time, consciousness, multiverse
 
-**Key distinction**: These extensions are exploratory. The core predictive success of GIFT (165+ proven relations, 39 observables) does not depend on resolving these speculative questions.
+**Key distinction**: These extensions are exploratory. The core predictive success of GIFT (180+ proven relations, 39 observables) does not depend on resolving these speculative questions.
 
 ---
 

--- a/docs/wip/JOYCE_FORMALIZATION_COMPLETE.md
+++ b/docs/wip/JOYCE_FORMALIZATION_COMPLETE.md
@@ -626,7 +626,7 @@ Certified Constants (Algebra.lean)
 ├── b2 = 21, b3 = 77, H_star = 99
 ├── dim_G2 = 14, dim_E8 = 248
 ├── det_g = 65/32, kappa_T = 1/61
-└── ...165+ relations
+└── ...180+ relations
 
         ↓ (used by)
 

--- a/notebooks/k7_metric_export.md
+++ b/notebooks/k7_metric_export.md
@@ -1,6 +1,6 @@
 # K₇ Metric Formalization
 
-**GIFT v3.0** | Generated: 2025-12-09
+**GIFT v3.1** | Generated: 2025-12-17
 
 ## Topological Constants
 
@@ -44,4 +44,4 @@ m_τ/m_e = 3477 = 3 × 19 × 61
 
 - **Lean 4**: `GIFT/Geometry.lean`, `GIFT/Certificate.lean`
 - **Coq**: `COQ/Geometry/K7.v`
-- **Relations certified**: 165+
+- **Relations certified**: 180+

--- a/publications/Lean/G2_Lean_v2.md
+++ b/publications/Lean/G2_Lean_v2.md
@@ -18,7 +18,7 @@ Our pipeline transforms numerical solutions into formally verified existence pro
 
 **Version 2.0 improvements** over v1.0:
 - **Dual verification**: Lean 4 + Coq (defense in depth against kernel bugs)
-- **Broader context**: The K₇ construction is embedded in a framework with 165+ certified relations connecting G₂ geometry to E₈, number theory, and exceptional groups (see [GIFT repository](https://github.com/gift-framework/core) for complete catalog)
+- **Broader context**: The K₇ construction is embedded in a framework with 180+ certified relations connecting G₂ geometry to E₈, number theory, and exceptional groups (see [GIFT repository](https://github.com/gift-framework/core) for complete catalog)
 - **Statistical validation**: 10,000 alternative configurations tested, showing 6.25σ separation
 - **Python package**: `pip install giftpy` for instant access to certified constants
 
@@ -74,7 +74,7 @@ We propose a three-phase pipeline that circumvents these technical barriers whil
 
 | Aspect | v1.0 (Dec 2025) | v2.0 (Dec 2025) | Improvement |
 |--------|-----------------|-----------------|-------------|
-| **Certified Relations** | 25 | **165+** | **6.6× increase** |
+| **Certified Relations** | 25 | **180+** | **6.6× increase** |
 | **Proof Systems** | Lean 4 only | **Lean 4 + Coq** | Dual verification |
 | **Domain Coverage** | G₂ topology | **+ E₈, Monster, McKay, Primes** | Deep structure |
 | **Number Theory** | Basic | **Fibonacci/Lucas embedding, Prime Atlas** | Complete |
@@ -86,7 +86,7 @@ We propose a three-phase pipeline that circumvents these technical barriers whil
 1. **Methodological**: PINN-to-proof pipeline for geometric PDEs, with explicit threat model and soundness guarantees (§5.4), dual-verified in two independent proof assistants.
 
 2. **Formal verification**: 
-   - **165+ relations** proven in both Lean 4 (Mathlib 4.14.0) and Coq (8.18)
+   - **180+ relations** proven in both Lean 4 (Mathlib 4.14.0) and Coq (8.18)
    - **Zero domain axioms** (only core: Lean's `propext`/`Quot.sound`, Coq's standard axioms)
    - **Constructive** existence proof for torsion-free structure
    - **Complete Fibonacci embedding**: F₃=2=p₂, F₄=3=N_gen, F₅=5=Weyl, ..., F₈=21=b₂, F₉=34=hidden_dim
@@ -111,7 +111,7 @@ We emphasize transparency about modeling choices:
 - ✓ Satisfaction of topological constraints (Hodge numbers, determinant condition)
 - ✓ Lipschitz bounds derived from PINN gradient analysis
 - ✓ Kernel-checked Lean 4 + Coq proofs with constructive fixed-point witness
-- ✓ **165+ exact mathematical relations** connecting G₂ geometry to E₈, Monster, number theory
+- ✓ **180+ exact mathematical relations** connecting G₂ geometry to E₈, Monster, number theory
 - ✓ **Statistical validation** showing 6.25σ separation from alternative configurations
 
 Our contribution is a *proof-of-concept* demonstrating feasibility of formal certification for ML-assisted geometry, now extended to a comprehensive web of connections across mathematics and theoretical physics.
@@ -128,7 +128,7 @@ This accessibility constraint also shaped technical choices (simplified geometry
 
 ### 1.5 Paper Organization
 
-§2 highlights what's new in v2.0. §3 provides a **Lean 4 primer for physicists**, a pedagogical introduction to theorem proving. §4 covers background on G₂ geometry and formal verification landscape. §5 details our three-phase pipeline. §6 walks through the Lean 4 + Coq implementation. §7 catalogs the 165+ certified relations. §8 explores deep structures (Fibonacci, primes, Monster). §9 presents validation and reproducibility. §10 discusses limitations and future work. An annex provides statistical validation details.
+§2 highlights what's new in v2.0. §3 provides a **Lean 4 primer for physicists**, a pedagogical introduction to theorem proving. §4 covers background on G₂ geometry and formal verification landscape. §5 details our three-phase pipeline. §6 walks through the Lean 4 + Coq implementation. §7 catalogs the 180+ certified relations. §8 explores deep structures (Fibonacci, primes, Monster). §9 presents validation and reproducibility. §10 discusses limitations and future work. An annex provides statistical validation details.
 
 ---
 
@@ -145,7 +145,7 @@ Version 2.0 represents a fundamental expansion from a focused G₂ formalization
 | **Prime Atlas** | 50+ | All primes < 200, Heegner numbers |
 | **Monster Group** | 15+ | Dimension, j-invariant, Moonshine |
 | **McKay** | 10+ | E₈ ↔ Icosahedron, golden ratio emergence |
-| **TOTAL** | **165+** | All dual-verified (Lean 4 + Coq) |
+| **TOTAL** | **180+** | All dual-verified (Lean 4 + Coq) |
 
 ### 2.2 Qualitative Breakthroughs
 
@@ -215,7 +215,7 @@ The McKay correspondence connects finite groups to exceptional Lie algebras. Our
 
 **5. Dual Verification (Lean 4 + Coq)**
 
-All 165+ relations are independently verified in:
+All 180+ relations are independently verified in:
 - **Lean 4.14.0** with Mathlib 4.14.0 (Zero sorry, zero domain axioms)
 - **Coq 8.18** (Zero Admitted, zero explicit axioms)
 
@@ -266,7 +266,7 @@ Lean/GIFT/
 ├── McKay/               # NEW in v2.0
 │   ├── Correspondence.lean    # E₈ ↔ 2I
 │   └── GoldenEmergence.lean   # φ via McKay chain
-└── Certificate.lean     # Master theorems (all_165+_certified)
+└── Certificate.lean     # Master theorems (all_180+_certified)
 ```
 
 Matching structure in `COQ/` with identical theorem statements.
@@ -302,7 +302,7 @@ print(COXETER_E8)  # 30 (icosahedron edges)
 
 ## 3. Lean 4 Primer for Physicists
 
-*This section makes formal verification accessible to theoretical physicists with no prior Lean experience. We progress from "Hello World" to understanding our 165+ certified relations.*
+*This section makes formal verification accessible to theoretical physicists with no prior Lean experience. We progress from "Hello World" to understanding our 180+ certified relations.*
 
 ### 3.1 Why Lean for Physics?
 
@@ -449,7 +449,7 @@ These are **Lean's core axioms**, present in all Lean proofs. Critically absent:
 - ❌ `Classical.em` (excluded middle): many proofs are constructive
 - ❌ Any physics-specific axioms: all derived from topology
 
-**For physicists**: This is like checking that your calculation doesn't depend on any unproven conjectures. Our G₂ existence proof and all 165+ relations are as solid as 2 + 2 = 4.
+**For physicists**: This is like checking that your calculation doesn't depend on any unproven conjectures. Our G₂ existence proof and all 180+ relations are as solid as 2 + 2 = 4.
 
 ### 3.7 From Physics Intuition to Formal Proof
 
@@ -723,22 +723,22 @@ cd COQ && make
 | Monster | 240 | 220 | Dimension, j-invariant |
 | McKay | 180 | 160 | Correspondence, golden |
 | Certificate | 420 | 380 | Master theorems |
-| **TOTAL** | **~3600** | **~3290** | **165+** |
+| **TOTAL** | **~3600** | **~3290** | **180+** |
 
 ---
 
 ## 7. The G₂ Construction in Broader Context
 
-### 7.1 The GIFT Framework (165+ Certified Relations)
+### 7.1 The GIFT Framework (180+ Certified Relations)
 
-The K₇ manifold constructed in this paper is part of a larger framework (GIFT - Geometric Information Field Theory) with **165+ formally verified mathematical relations** connecting:
+The K₇ manifold constructed in this paper is part of a larger framework (GIFT - Geometric Information Field Theory) with **180+ formally verified mathematical relations** connecting:
 
 - **G₂ topology**: b₂=21, b₃=77, κ_T=1/61, det(g)=65/32
 - **E₈ structure**: dim(E₈)=248, exceptional chain E₆→E₇→E₈
 - **Number theory**: Fibonacci embedding (F₃...F₁₂), Prime Atlas (<200), Heegner numbers
 - **Exceptional groups**: Monster dimension 196883=47×59×71, McKay correspondence
 
-**This paper focuses on the G₂ metric construction methodology**. For the complete catalog of 165+ relations, see:
+**This paper focuses on the G₂ metric construction methodology**. For the complete catalog of 180+ relations, see:
 - Repository: https://github.com/gift-framework/core
 - Python package: `pip install giftpy`
 - Full framework paper: GIFT v3.0 (forthcoming)
@@ -793,9 +793,9 @@ theorem k7_admits_torsion_free_g2 :
 -- Only Lean's core axioms, NO domain-specific axioms
 ```
 
-### 7.3 Broader Context (165+ Relations)
+### 7.3 Broader Context (180+ Relations)
 
-The K₇ topology (b₂=21, b₃=77) is embedded in a rich mathematical structure with 165+ certified relations. **Examples include**:
+The K₇ topology (b₂=21, b₃=77) is embedded in a rich mathematical structure with 180+ certified relations. **Examples include**:
 
 - **Fibonacci embedding**: F₈ = 21 = b₂ (remarkably, the Fibonacci sequence F₃...F₁₂ maps exactly to GIFT constants)
 - **Prime expressions**: 163 = dim(E₈) - 10×rank(E₈) - 5 (Heegner prime!)
@@ -847,7 +847,7 @@ git clone https://github.com/gift-framework/core
 cd core/Lean && lake build
 cd ../COQ && make
 ```
-Verifies all 165+ relations. **Requires**: Lean 4.14, Coq 8.18, 4GB RAM.
+Verifies all 180+ relations. **Requires**: Lean 4.14, Coq 8.18, 4GB RAM.
 
 **Level 2: Python Package**
 ```bash
@@ -1006,7 +1006,7 @@ $$J(\varphi) = \varphi - (d + d^*)^{-1} \left( \begin{array}{c} d\varphi \\ d\st
 
 We have presented a pipeline from physics-informed neural networks to formally verified existence theorems in differential geometry, applied to a model of G₂ structures, with **dual independent verification** in Lean 4 and Coq.
 
-**Version 2.0 represents a qualitative leap**, extending from 25 to **165+ certified mathematical relations**, establishing deep connections between:
+**Version 2.0 represents a qualitative leap**, extending from 25 to **180+ certified mathematical relations**, establishing deep connections between:
 - G₂ geometry and E₈ exceptional structure
 - Fibonacci/Lucas sequences (complete embedding)
 - Prime numbers (100% coverage < 200)
@@ -1018,7 +1018,7 @@ Our contributions include:
 
 1. **Methodological**: PINN-to-proof pipeline with explicit soundness guarantees, dual-verified in independent proof systems
 
-2. **Technical**: **165+ relations** proven in Lean 4 (Mathlib 4.14.0) and Coq (8.18), with **zero domain axioms**, constructive existence proof for torsion-free structure
+2. **Technical**: **180+ relations** proven in Lean 4 (Mathlib 4.14.0) and Coq (8.18), with **zero domain axioms**, constructive existence proof for torsion-free structure
 
 3. **Reproducible**: Open-source implementation (`pip install giftpy`), executable on free-tier cloud hardware (<1 hour)
 

--- a/publications/README.md
+++ b/publications/README.md
@@ -1,4 +1,4 @@
-# GIFT Framework v3.0 - Publications
+# GIFT Framework v3.1 - Publications
 
 [![Lean 4 Verified](https://img.shields.io/badge/Lean_4-Verified-blue)](https://github.com/gift-framework/core/tree/main/Lean)
 [![Coq Verified](https://img.shields.io/badge/Coq_8.18-Verified-orange)](https://github.com/gift-framework/core/tree/main/COQ)
@@ -11,10 +11,11 @@ Geometric Information Field Theory: Deriving Standard Model parameters from E₈
 
 ```
 publications/
-├── markdown/                    # Core documents (v3.0)
+├── markdown/                    # Core documents (v3.1)
 │   ├── GIFT_v3_main.md         # Main paper
 │   ├── GIFT_v3_S1_foundations.md   # E₈, G₂, K₇ foundations
-│   └── GIFT_v3_S2_derivations.md   # 18 dimensionless derivations
+│   ├── GIFT_v3_S2_derivations.md   # 18 dimensionless derivations
+│   └── GIFT_v3_S3_dynamics.md      # RG flow, torsional dynamics
 │
 ├── references/                  # Exploratory & reference docs
 │   ├── 39_observables.csv      # Machine-readable data
@@ -41,6 +42,9 @@ Mathematical foundations: E₈ exceptional algebra, G₂ holonomy, K₇ manifold
 
 ### [GIFT_v3_S2_derivations.md](markdown/GIFT_v3_S2_derivations.md)
 All 18 dimensionless derivations with complete proofs.
+
+### [GIFT_v3_S3_dynamics.md](markdown/GIFT_v3_S3_dynamics.md)
+RG flow, torsional dynamics, scale bridge.
 
 ---
 
@@ -91,5 +95,5 @@ Historical supplements (S1-S9 v2.3/v3.0) are archived in `../docs/legacy/`.
 
 ---
 
-**Version**: 3.0.0 (2025-12-11)
+**Version**: 3.1.1 (2025-12-17)
 **Repository**: https://github.com/gift-framework/GIFT

--- a/publications/markdown/GIFT_v3_main.md
+++ b/publications/markdown/GIFT_v3_main.md
@@ -66,7 +66,7 @@ The framework makes predictions that derive from the topological structure:
 
 3. **Algebraic relations**: Quantities involving irrational numbers that nonetheless derive from the geometric structure, such as alpha_s = sqrt(2)/12.
 
-For complete mathematical details of the E8 and G2 structures, see Supplement S1. For derivations of all dimensionless predictions, see Supplement S2.
+For complete mathematical details of the E8 and G2 structures, see Supplement S1. For derivations of all dimensionless predictions, see Supplement S2. For RG flow, torsional dynamics, and scale bridge, see Supplement S3.
 
 ### 1.4 Organization
 

--- a/publications/references/README.md
+++ b/publications/references/README.md
@@ -1,6 +1,6 @@
 # GIFT Reference Documents
 
-Exploratory and reference documents for the GIFT framework v3.0.
+Exploratory and reference documents for the GIFT framework v3.1.
 
 ---
 
@@ -58,7 +58,8 @@ For the main framework documents, see [`../markdown/`](../markdown/):
 - [GIFT_v3_main.md](../markdown/GIFT_v3_main.md) - Main paper
 - [GIFT_v3_S1_foundations.md](../markdown/GIFT_v3_S1_foundations.md) - Foundations
 - [GIFT_v3_S2_derivations.md](../markdown/GIFT_v3_S2_derivations.md) - Derivations
+- [GIFT_v3_S3_dynamics.md](../markdown/GIFT_v3_S3_dynamics.md) - Dynamics
 
 ---
 
-*Part of GIFT Framework v3.0*
+*Part of GIFT Framework v3.1*


### PR DESCRIPTION
- Add S3 (Dynamics) to all main paper listings
- Update version numbers from v3.0 to v3.1 across all READMEs
- Update relation count from 165+ to 180+ in non-legacy docs:
  - docs/LEAN_FOR_PHYSICS.md
  - docs/technical/JOYCE_FORMALIZATION.md
  - docs/technical/S6_theoretical_extensions_v30.md
  - docs/wip/JOYCE_FORMALIZATION_COMPLETE.md
  - notebooks/k7_metric_export.md
  - publications/Lean/G2_Lean_v2.md
- Update publications/README.md structure to include S3
- Reference S3 in main paper intro section

Legacy files (docs/legacy/*) intentionally unchanged.