### PR TITLE
docs: version evolution from all publications

### DIFF
--- a/publications/markdown/GIFT_v3_S1_foundations.md
+++ b/publications/markdown/GIFT_v3_S1_foundations.md
@@ -4,16 +4,15 @@
 
 ## E₈ Exceptional Lie Algebra, G₂ Holonomy Manifolds, and K₇ Construction
 
-*Complete mathematical foundations for GIFT v3.1, merging E₈ architecture with K₇ manifold construction.*
+*Complete mathematical foundations for GIFT, presenting E8 architecture and K7 manifold construction.*
 
-**Version**: 3.1
 **Lean Verification**: 180+ relations, 0 sorry
 
 ---
 
 ## Abstract
 
-We present the mathematical architecture underlying GIFT v3.1. Part I develops E₈ exceptional Lie algebra with the Exceptional Chain theorem. Part II introduces G₂ holonomy manifolds. Part III establishes K₇ manifold construction via twisted connected sum, which builds compact G₂ manifolds by gluing asymptotically cylindrical building blocks. Part IV establishes that the resulting metric is exactly the scaled standard G₂ form, with analytically vanishing torsion. This supplement presents the analytical solution with formal Lean 4 verification.
+This supplement presents the mathematical architecture underlying GIFT. Part I develops E8 exceptional Lie algebra with the Exceptional Chain theorem. Part II introduces G2 holonomy manifolds. Part III establishes K7 manifold construction via twisted connected sum, building compact G2 manifolds by gluing asymptotically cylindrical building blocks. Part IV establishes that the resulting metric is exactly the scaled standard G2 form, with analytically vanishing torsion. All results are formally verified in Lean 4.
 
 ---
 
@@ -221,7 +220,7 @@ For the 3-form φ, torsion decomposes into four classes W₁ ⊕ W₇ ⊕ W₁�
 **Torsion-free condition**:
 $$\nabla\phi = 0 \Leftrightarrow d\phi = 0 \text{ and } d*\phi = 0$$
 
-**GIFT interpretation (v3.1)**:
+**GIFT interpretation**:
 
 | Quantity | Meaning | Value |
 |----------|---------|-------|
@@ -550,7 +549,7 @@ This supplement establishes the mathematical foundations:
 - Betti numbers b₂ = 21, b₃ = 77 (exact)
 - Cohomological decomposition
 
-**Part IV - Analytical Solution (v3.1)**:
+**Part IV - Analytical Solution**:
 - Exact closed form: φ = (65/32)^{1/14} × φ₀
 - Metric: g = (65/32)^{1/7} × I₇
 - Torsion: T = 0 exactly
@@ -570,5 +569,5 @@ This supplement establishes the mathematical foundations:
 
 ---
 
-*GIFT Framework v3.1 - Supplement S1*
-*Mathematical Foundations: E₈ + G₂ + K₇*
+*GIFT Framework - Supplement S1*
+*Mathematical Foundations: E8 + G2 + K7*

--- a/publications/markdown/GIFT_v3_S2_derivations.md
+++ b/publications/markdown/GIFT_v3_S2_derivations.md
@@ -6,10 +6,9 @@
 
 *This supplement provides complete mathematical proofs for all dimensionless predictions in the GIFT framework. Each derivation proceeds from topological definitions to exact numerical predictions.*
 
-**Version**: 3.1
 **Status**: Complete (18 PROVEN relations)
 
-**Note (v3.1)**: All derivations in this supplement remain unchanged. The discovery of the analytical metric (see S1, Section 12) provides additional confidence: the topological constants that determine these relations produce an exactly solvable geometric structure.
+The topological constants that determine these relations produce an exactly solvable geometric structure (see S1, Section 12).
 
 ---
 
@@ -56,7 +55,7 @@ Before presenting derivations, we clarify the logical structure:
 
 ### 0.4 Torsion Independence
 
-**Critical v3.1 clarification**: All 18 predictions use only topological invariants. The torsion T does not appear in any formula. Therefore:
+**Important**: All 18 predictions use only topological invariants. The torsion T does not appear in any formula. Therefore:
 - Predictions are identical whether T = 0 (analytical) or T = κ_T (capacity)
 - The value κ_T = 1/61 is a topological bound, not a prediction ingredient
 
@@ -168,7 +167,7 @@ $$\kappa_T = \frac{1}{b_3 - \dim(G_2) - p_2} = \frac{1}{61}$$
 - 61 = effective degrees of freedom available for torsional deformation
 - 61 = dim(F₄) + N_gen² = 52 + 9
 
-### Important Clarification (v3.1)
+### Clarification
 
 | Quantity | Definition | Value |
 |----------|------------|-------|
@@ -204,7 +203,7 @@ $$\det(g) = 2 + \frac{1}{32} = \frac{65}{32}$$
 *Step 4: Alternative derivation*
 $$\det(g) = \frac{\text{Weyl} \times (\text{rank}(E_8) + \text{Weyl})}{2^5} = \frac{5 \times 13}{32} = \frac{65}{32}$$
 
-**Verification (v3.1)**: The analytical metric g = (65/32)^{1/7} × I₇ has det(g) = [(65/32)^{1/7}]⁷ = 65/32 exactly, confirming the topological formula.
+**Verification**: The analytical metric g = (65/32)^{1/7} x I7 has det(g) = [(65/32)^{1/7}]^7 = 65/32 exactly, confirming the topological formula.
 
 **Status**: TOPOLOGICAL ∎
 
@@ -600,7 +599,7 @@ $$= 128 + 9 + \frac{65}{32} \times \frac{1}{61} = 137.033$$
 
 ## 21. The 18 PROVEN Dimensionless Relations
 
-**Note (v3.1)**: All predictions use only topological invariants (b₂, b₃, dim(G₂), etc.). None depend on the realized torsion value T.
+**Note**: All predictions use only topological invariants (b2, b3, dim(G2), etc.). None depend on the realized torsion value T.
 
 | # | Relation | Formula | Value | Exp. | Dev. | Status |
 |---|----------|---------|-------|------|------|--------|
@@ -650,5 +649,5 @@ $$= 128 + 9 + \frac{65}{32} \times \frac{1}{61} = 137.033$$
 
 ---
 
-*GIFT Framework v3.1 - Supplement S2*
+*GIFT Framework - Supplement S2*
 *Complete Derivations: 18 Dimensionless Relations*

--- a/publications/markdown/GIFT_v3_S3_dynamics.md
+++ b/publications/markdown/GIFT_v3_S3_dynamics.md
@@ -4,14 +4,13 @@
 
 *This supplement bridges the static topological structure of S1-S2 to physical dynamics. It explores torsional geodesic flow, discusses the scale bridge from Planck to electroweak scales, and presents cosmological predictions.*
 
-**Version**: 3.1
 **Date**: December 2025
 
 ---
 
 ## Abstract
 
-The GIFT framework's dimensionless predictions (S2) require dynamical completion to connect with absolute physical scales. Version 3.1 establishes that the base G₂ metric is exactly the scaled standard form with T = 0. This supplement explores how departures from this exact solution (through moduli variation or quantum corrections) could generate the small effective torsion that enables physical interactions.
+The GIFT framework's dimensionless predictions (S2) require dynamical completion to connect with absolute physical scales. The base G2 metric is exactly the scaled standard form with T = 0. This supplement explores how departures from this exact solution (through moduli variation or quantum corrections) could generate the small effective torsion that enables physical interactions.
 
 This supplement provides three essential bridges:
 
@@ -99,7 +98,7 @@ Equivalent to closure conditions:
 
 $$d\phi = 0, \quad d*\phi = 0$$
 
-**Exact Solution (v3.1)**
+**Exact Solution**
 
 The constant form φ = c × φ₀ satisfies:
 - dφ = 0, d*φ = 0 (trivially, for constant form)
@@ -146,7 +145,7 @@ $$61 = \text{prime}(18)$$
 ### 2.3 Critical Distinction: Capacity vs Realized Value
 
 ┌─────────────────────────────────────────────────────────────┐
-│  **IMPORTANT (v3.1)**                                       │
+│  **IMPORTANT**                                              │
 │                                                             │
 │  kappa_T = 1/61 is the CAPACITY, the maximum torsion that   │
 │  K₇ topology permits while preserving G₂ holonomy.         │
@@ -1044,7 +1043,7 @@ $$H_0^{Local} = b_3 - p_2^2 = 73$$
 
 ---
 
-## 27. Status Summary (v3.1)
+## 27. Status Summary
 
 ### 27.1 What is PROVEN (S2)
 
@@ -1118,5 +1117,5 @@ $$H_0^{Local} = b_3 - p_2^2 = 73$$
 
 ---
 
-*GIFT Framework v3.1 - Supplement S3*
+*GIFT Framework - Supplement S3*
 *Dynamics and Scale Bridge*

--- a/publications/markdown/GIFT_v3_main.md
+++ b/publications/markdown/GIFT_v3_main.md
@@ -245,7 +245,7 @@ $$H^* = b_2 + b_3 + 1 = 21 + 77 + 1 = 99$$
 **Torsion capacity** (not magnitude):
 $$\kappa_T = \frac{1}{b_3 - \dim(G_2) - p_2} = \frac{1}{77 - 14 - 2} = \frac{1}{61}$$
 
-**Important distinction (v3.1)**: This value represents the geometric *capacity* for torsion, the maximum departure from exact G2 holonomy that K7 topology permits. For the analytical solution φ = c × φ₀, the realized torsion is exactly T = 0 (see Section 3.4). The value κ_T = 1/61 bounds fluctuations; it does not appear directly in the 18 dimensionless predictions.
+**Important distinction**: This value represents the geometric *capacity* for torsion, the maximum departure from exact G2 holonomy that K7 topology permits. For the analytical solution φ = c × φ₀, the realized torsion is exactly T = 0 (see Section 3.4). The value κ_T = 1/61 bounds fluctuations; it does not appear directly in the 18 dimensionless predictions.
 
 The denominator 61 = dim(F₄) + N_gen² = 52 + 9 connects to exceptional algebras, suggesting the bound has physical significance even when saturated at T = 0.
 
@@ -270,7 +270,7 @@ These 77 modes organize into 3 generations via the constraint N_gen = 3 derived 
 
 ### 3.4 The Analytical G₂ Metric (Central Result)
 
-The following discovery (v3.1) transforms GIFT from numerical fitting to algebraic derivation.
+The G2 metric admits an exact closed form, which is central to the framework.
 
 **The Standard Associative 3-form**
 
@@ -300,13 +300,13 @@ Therefore the torsion tensor T = 0 exactly, satisfying Joyce's threshold ‖T‖
 
 **Why this matters**:
 
-| Aspect | Before v3.1 | After v3.1 |
-|--------|-------------|------------|
-| Metric source | PINN reconstruction | Exact algebraic form |
-| Torsion | κ_T = 1/61 (realized) | T = 0 (capacity = 1/61) |
-| Joyce threshold | 20× margin | Infinite margin |
-| Parameter count | Zero continuous | Zero continuous (confirmed) |
-| Verification | Numerical | Lean 4 theorem |
+| Property | Value |
+|----------|-------|
+| Metric source | Exact algebraic form |
+| Torsion | T = 0 (capacity = 1/61) |
+| Joyce threshold | Satisfied with infinite margin |
+| Parameter count | Zero continuous |
+| Verification | Lean 4 theorem + PINN cross-check |
 
 The constant form phi = c x phi_0 is not an approximation; it is the exact solution. Independent PINN validation confirms convergence to this form, providing cross-verification between analytical and numerical methods.
 
@@ -496,7 +496,7 @@ The hierarchy parameter τ = 3472/891 has prime factorization (2⁴ × 7 × 31)/
 
 The torsion inverse 61 = dim(F₄) + N_gen² = 52 + 9 links to exceptional algebra structure.
 
-**Note on torsion independence (v3.1)**: All 18 predictions derive from topological invariants (b₂, b₃, dim(G₂), etc.) and are independent of the realized torsion value T. The analytical metric has T = 0 exactly; the predictions would be identical for any T ≤ κ_T = 1/61.
+**Note on torsion independence**: All 18 predictions derive from topological invariants (b2, b3, dim(G2), etc.) and are independent of the realized torsion value T. The analytical metric has T = 0 exactly; the predictions would be identical for any T within the capacity bound.
 
 ---
 
@@ -801,7 +801,7 @@ E₈×E₈ algebra  ←→  ?  ←→  G₂ holonomy  ←→  ?  ←→  SM para
 
 GIFT derives 18 dimensionless predictions from a single geometric structure: a G₂-holonomy manifold K₇ with Betti numbers (21, 77) coupled to E₈×E₈ gauge symmetry. The framework contains zero continuous parameters. Mean deviation is 0.087%, with the 43-year Koide mystery resolved by Q = dim(G₂)/b₂ = 2/3.
 
-The v3.1 discovery that the G₂ metric is exactly φ = (65/32)^{1/14} × φ₀ with T = 0 elevates GIFT from numerical fitting to algebraic derivation.
+The G2 metric is exactly phi = (65/32)^{1/14} x phi_0 with T = 0, making all predictions algebraically exact rather than numerically fitted.
 
 Whether GIFT represents successful geometric unification or elaborate coincidence is a question experiment will answer. By 2039, DUNE will confirm or refute δ_CP = 197° to ±5° precision.
 
@@ -921,6 +921,6 @@ The octonion-Cayley connection and its role in G₂ structure benefited from ins
 
 ---
 
-*GIFT Framework v3.1*
+*GIFT Framework*
 *Mean Deviation: 0.087%*
-*Decisive Test: DUNE 2028-2030*
+*Decisive Test: DUNE 2034-2039*


### PR DESCRIPTION
Remove all v3.1 markers, "discovery" language, and before/after comparisons. The documents now present the framework as it stands, without evolutionary history (handled by CHANGELOG and Zenodo).

Changes:
- Remove "(v3.1)" markers throughout
- Replace "discovery" with neutral descriptions
- Remove Before/After comparison tables
- Simplify version footers to "GIFT Framework"
- Present analytical metric as fact, not evolution