### PR TITLE
Apply GIFT v3.1 revision plan

### DIFF
--- a/publications/markdown/GIFT_v3_S1_foundations.md
+++ b/publications/markdown/GIFT_v3_S1_foundations.md
@@ -16,6 +16,67 @@ This supplement presents the mathematical architecture underlying GIFT. Part I d
 
 ---
 
+# Part 0: The Octonionic Foundation
+
+## 0. Why This Framework Exists
+
+GIFT is not built on arbitrary choices. It emerges from a single algebraic fact:
+
+**The octonions 𝕆 are the largest normed division algebra.**
+
+Everything follows:
+
+```
+𝕆 (octonions, dim 8)
+    │
+    ▼
+Im(𝕆) = ℝ⁷ (imaginary octonions)
+    │
+    ▼
+G₂ = Aut(𝕆) (automorphism group, dim 14)
+    │
+    ▼
+K₇ with G₂ holonomy (unique compact realization)
+    │
+    ▼
+Topological invariants (b₂ = 21, b₃ = 77)
+    │
+    ▼
+18 dimensionless predictions
+```
+
+### 0.1 The Division Algebra Chain
+
+| Algebra | Dim | Physics Role | Stops? |
+|---------|-----|--------------|--------|
+| ℝ | 1 | Classical mechanics | No |
+| ℂ | 2 | Quantum mechanics | No |
+| ℍ | 4 | Spin, Lorentz group | No |
+| **𝕆** | **8** | **Exceptional structures** | **Yes** |
+
+The pattern terminates at 𝕆. There is no 16-dimensional normed division algebra. The octonions are *the end of the line*.
+
+### 0.2 G₂ as Octonionic Automorphisms
+
+**Definition**: G₂ = {g ∈ GL(𝕆) : g(xy) = g(x)g(y) for all x,y ∈ 𝕆}
+
+| Property | Value | GIFT Role |
+|----------|-------|-----------|
+| dim(G₂) | 14 = C(7,2) | Q_Koide numerator |
+| Action | Transitive on S⁶ ⊂ Im(𝕆) | Connects all directions |
+| Embedding | G₂ ⊂ SO(7) | Preserves φ₀ |
+
+### 0.3 Why dim(K₇) = 7
+
+This is not a choice. It is a consequence:
+- Im(𝕆) has dimension 7
+- G₂ acts naturally on ℝ⁷
+- A compact 7-manifold with G₂ holonomy is the geometric realization
+
+**K₇ is to G₂ what the circle is to U(1).**
+
+---
+
 # Part I: E₈ Exceptional Lie Algebra
 
 ## 1. Root System and Dynkin Diagram
@@ -86,7 +147,7 @@ $$|W(E_8)| = p_2^{\dim(G_2)} \times N_{gen}^{Weyl} \times Weyl^{p_2} \times \dim
 
 ### 3.1 The Pattern
 
-A remarkable pattern connects exceptional algebra dimensions to primes:
+A pattern connects exceptional algebra dimensions to primes:
 
 | Algebra | n | dim(E_n) | Prime | Index |
 |---------|---|----------|-------|-------|
@@ -137,19 +198,9 @@ $$\tau_{num} = 3472 = 7 \times 496 = \dim(K_7) \times \dim(E_8 \times E_8)$$
 
 ---
 
-## 5. Octonionic Structure (Foundational)
+## 5. Exceptional Algebras from Octonions
 
-The octonions are not an optional feature of GIFT; they are its foundation. All subsequent structure (G₂, K₇, predictions) derives from 𝕆.
-
-### Why Octonions?
-
-The four normed division algebras over ℝ are:
-- ℝ (dim 1): Classical mechanics
-- ℂ (dim 2): Quantum mechanics
-- ℍ (dim 4): Spin, SL(2,ℂ), Lorentz group
-- **𝕆 (dim 8): Exceptional structures, GIFT**
-
-The pattern stops at 𝕆. There is no 16-dimensional division algebra. The octonions are the *last* algebra with the properties needed for physics.
+The foundational role of octonions is established in Part 0. This section details the exceptional algebraic structures that emerge from 𝕆.
 
 ### 5.1 Exceptional Jordan Algebra J₃(O)
 
@@ -172,22 +223,6 @@ $$\dim(F_4) = 52 = p_2^2 \times \alpha_{sum}^B = 4 \times 13$$
 | dim(E₆) - dim(F₄) | 26 | dim(J₃(O)₀) |
 
 **Status**: **PROVEN (Lean)**: `exceptional_differences_certified`
-
-### 5.4 G₂ as Octonionic Automorphisms
-
-**Definition**: G₂ = {g ∈ GL(𝕆) : g(xy) = g(x)g(y) for all x,y ∈ 𝕆}
-
-**Key facts**:
-- dim(G₂) = 14 = C(7,2) (pairs of imaginary units)
-- G₂ acts transitively on unit imaginary octonions (S⁶)
-- G₂ ⊂ SO(7) is the stabilizer of the associative 3-form φ₀
-
-**Connection to K₇**:
-- Im(𝕆) = ℝ⁷ is the natural 7-dimensional space
-- G₂ holonomy means parallel transport preserves octonionic multiplication
-- K₇ is the compact geometry realizing this structure
-
-This is why dim(K7) = 7 and why G2 holonomy is required: not choices, but consequences of using octonions.
 
 ---
 

--- a/publications/markdown/GIFT_v3_S2_derivations.md
+++ b/publications/markdown/GIFT_v3_S2_derivations.md
@@ -399,7 +399,7 @@ $$\delta_{CP} = \dim(K_7) \cdot \dim(G_2) + H^* = 7 \times 14 + 99 = 98 + 99 = 1
 | GIFT prediction | 197° (exact) |
 | Deviation | 0.00% |
 
-**Note**: DUNE (2027-2028) will test to ±5°.
+**Note**: DUNE (2034-2039) will test to ±5° precision. Hyper-Kamiokande provides independent verification starting ~2034.
 
 **Status**: PROVEN ∎
 
@@ -613,7 +613,7 @@ $$= 128 + 9 + \frac{65}{32} \times \frac{1}{61} = 137.033$$
 | 8 | m_τ/m_e | 7+2480+990 | 3477 | 3477.15 | 0.0043% | PROVEN |
 | 9 | m_μ/m_e | 27^φ | 207.01 | 206.768 | 0.118% | TOPOLOGICAL |
 | 10 | m_s/m_d | 4×5 | 20 | 20.0 | 0.00% | PROVEN |
-| 11 | δ_CP | 98+99 | 197° | 197° | 0.00% | PROVEN |
+| 11 | δ_CP | 7×14+99 | 197° | 197° | 0.00% | PROVEN |
 | 12 | θ₁₃ | π/21 | 8.57° | 8.54° | 0.368% | TOPOLOGICAL |
 | 13 | θ₂₃ | (rank+b3)/H* | 49.19° | 49.3° | 0.216% | TOPOLOGICAL |
 | 14 | θ₁₂ | arctan(...) | 33.40° | 33.41° | 0.030% | TOPOLOGICAL |

--- a/publications/markdown/GIFT_v3_S3_dynamics.md
+++ b/publications/markdown/GIFT_v3_S3_dynamics.md
@@ -208,9 +208,25 @@ The small but non-zero torsion enables:
 
 ## 4. Torsion Tensor Components
 
-### 4.1 Coordinate System
+### 4.1 Important Clarification
 
-The K₇ metric is expressed in coordinates (e, π, φ) with physical interpretation:
+┌─────────────────────────────────────────────────────────────┐
+│  **THEORETICAL EXPLORATION**                                │
+│                                                             │
+│  The analytical GIFT solution has T = 0 exactly.            │
+│                                                             │
+│  The values in this section explore what torsion components │
+│  WOULD look like if physical interactions arise from        │
+│  fluctuations around the T = 0 base, bounded by κ_T = 1/61. │
+│                                                             │
+│  These are theoretical explorations, NOT predictions.       │
+│  The 18 dimensionless predictions (S2) do not use these     │
+│  values.                                                    │
+└─────────────────────────────────────────────────────────────┘
+
+### 4.2 Coordinate System (Theoretical)
+
+If we parameterize fluctuations away from the exact solution using coordinates with physical interpretation:
 
 | Coordinate | Physical Sector | Range |
 |------------|-----------------|-------|
@@ -218,45 +234,26 @@ The K₇ metric is expressed in coordinates (e, π, φ) with physical interpreta
 | π | Hadronic/strong | [0.1, 3.0] |
 | φ | Electroweak/Higgs | [0.1, 1.5] |
 
-### 4.2 Component Structure
+### 4.3 Hypothetical Component Structure
 
-From numerical metric reconstruction:
+From exploratory PINN reconstruction of torsionful G₂ structures (NOT the GIFT analytical solution):
 
-| Component | Value | Physical Role |
-|-----------|-------|---------------|
-| T_{eφ,π} | ~5 | Mass hierarchies (large ratios) |
-| T_{πφ,e} | ~0.5 | CP violation phase |
-| T_{eπ,φ} | ~10⁻⁵ | Jarlskog invariant |
+| Component | Order of Magnitude | Would Encode |
+|-----------|-------------------|--------------|
+| T_{eφ,π} | O(Weyl) ~ 5 | Mass hierarchies |
+| T_{πφ,e} | O(1/p₂) ~ 0.5 | CP violation |
+| T_{eπ,φ} | O(κ_T/b₂b₃) ~ 10⁻⁵ | Jarlskog invariant |
 
-**Key insight**: The torsion hierarchy directly encodes the observed hierarchy of physical observables.
+**Status**: THEORETICAL EXPLORATION — not part of core GIFT predictions.
 
-### 4.3 Physical Interpretation
+### 4.4 Physical Picture (Speculative)
 
-**T_{eφ,π} ≈ -4.89 (large)**:
-- Drives geodesics in (e,φ) plane
-- Source of mass hierarchies like m_τ/m_e = 3477
-- Large torsion amplifies path lengths
+If physical interactions emerge from quantum fluctuations around T = 0:
+- The *capacity* κ_T = 1/61 bounds the fluctuation amplitude
+- The *hierarchy* of components (large/medium/tiny) could explain the hierarchy of observables
+- The *base solution* T = 0 ensures mathematical consistency
 
-**T_{πφ,e} ≈ -0.45 (moderate)**:
-- Torsional twist in (π,φ) sector
-- Source of CP violation δ_CP = 197°
-- Accumulated geometric phase
-
-**T_{eπ,φ} ≈ 3×10⁻⁵ (tiny)**:
-- Weak electromagnetic-hadronic coupling
-- Related to Jarlskog invariant J ≈ 3×10⁻⁵
-
-### 4.4 Topological Structure of Torsion Components
-
-The torsion components emerge from the K₇ metric pipeline (PINN reconstruction) and admit approximate topological expressions. The hierarchy T_{eφ,π} >> T_{πφ,e} >> T_{eπ,φ} mirrors the hierarchy of physical observables:
-
-| Component | Approximate Formula | Physical Correspondence |
-|-----------|---------------------|------------------------|
-| T_{eφ,π} ~ 5 | O(Weyl) | Large mass ratios (3477) |
-| T_{πφ,e} ~ 0.5 | O(1/p₂) | CP violation phase (197°) |
-| T_{eπ,φ} ~ 10⁻⁵ | O(κ_T/(b₃ × b₂)) | Jarlskog invariant (~10⁻⁵) |
-
-**Note**: Exact closed-form expressions relating T_{ij,k} to GIFT constants remain an open problem. The numerical values are determined by the PINN-reconstructed metric, with topological formulas providing order-of-magnitude constraints.
+This mechanism is CONJECTURAL. The 18 proven predictions use only topology, not these torsion component values.
 
 ---
 

--- a/publications/markdown/GIFT_v3_main.md
+++ b/publications/markdown/GIFT_v3_main.md
@@ -110,7 +110,7 @@ The octonionic construction provides insight into E8's exceptional nature. The o
 G2 (14) -> F4 (52) -> E6 (78) -> E7 (133) -> E8 (248)
 ```
 
-A remarkable pattern connects these dimensions to prime numbers:
+A pattern connects these dimensions to prime numbers:
 - dim(E6) = 78 = 6 x 13 = 6 x prime(6)
 - dim(E7) = 133 = 7 x 19 = 7 x prime(8)
 - dim(E8) = 248 = 8 x 31 = 8 x prime(11)
@@ -341,7 +341,23 @@ Three classes of predictions emerge:
 
 ### 4.2 Epistemic Status
 
-The formulas presented here share epistemological status with Balmer's formula (1885) for hydrogen spectra: empirically successful descriptions whose theoretical derivation came later. Three factors distinguish GIFT predictions from numerology:
+The formulas presented here share epistemological status with Balmer's formula (1885) for hydrogen spectra: empirically successful descriptions whose theoretical derivation came later.
+
+#### What GIFT Claims
+
+1. **Given** the octonionic algebra 𝕆, its automorphism group G₂, the E₈×E₈ gauge structure, and the K₇ manifold (TCS construction with b₂ = 21, b₃ = 77)...
+2. **Then** the 18 dimensionless predictions follow by algebra
+3. **And** these match experiment to 0.087% mean deviation
+4. **With** zero continuous parameters fitted
+
+#### What GIFT Does NOT Claim
+
+1. That 𝕆 → G₂ → K₇ is the *unique* geometry for physics
+2. That the formulas are uniquely determined by geometric principles
+3. That the selection rule for specific combinations (e.g., b₂/(b₃ + dim_G₂) rather than b₂/b₃) is understood
+4. That dimensional quantities (masses in eV) have the same confidence as dimensionless ratios
+
+#### Three Factors Distinguishing GIFT from Numerology
 
 **1. Multiplicity**: 18 independent predictions, not cherry-picked coincidences. Random matching at 0.087% mean deviation across 18 quantities has probability < 10⁻²⁰.
 
@@ -354,7 +370,9 @@ These exact ratios cannot be "fitted"; they are correct or wrong.
 
 **3. Falsifiability**: DUNE will test δ_CP = 197° to ±5° precision by 2039. A single clear contradiction refutes the entire framework.
 
-**What remains open**: The principle selecting *these specific* algebraic combinations of topological invariants. Current status: the formulas work, the selection rule is unknown. This parallels Balmer → Bohr → Schrödinger: empirical success preceded theoretical derivation by decades.
+#### The Open Question
+
+The principle selecting *these specific* algebraic combinations of topological invariants remains unknown. Current status: the formulas work, the selection rule awaits discovery. This parallels Balmer → Bohr → Schrödinger: empirical success preceded theoretical derivation by decades.
 
 ### 4.3 Why Dimensionless Quantities
 
@@ -447,17 +465,53 @@ If the Koide relation truly equals 2/3 exactly, improved measurements of lepton 
 
 ## 7. CP Violation Phase
 
+### 7.1 The Formula
+
 **Formula**:
 $$\delta_{CP} = \dim(K_7) \times \dim(G_2) + H^* = 7 \times 14 + 99 = 197°$$
 
 **Comparison**: Current experimental range: 197° ± 24° (T2K + NOνA combined) → Deviation: **0.00%**
 
-**Falsification timeline** (updated December 2025):
-- Hyper-Kamiokande first results: ~2034 (5σ CPV discovery potential)
-- DUNE first results: ~2039 (5σ CPV discovery potential)
-- Combined precision: ±5° after 10 years operation
+### 7.2 Physical Interpretation
 
-**Decisive test**: Measurement outside 182°–212° at 3σ refutes GIFT.
+The formula decomposes into two contributions:
+
+| Term | Value | Origin | Interpretation |
+|------|-------|--------|----------------|
+| dim(K₇) × dim(G₂) | 7 × 14 = 98 | Local geometry | Fiber-holonomy coupling |
+| H* | 99 | Global cohomology | Topological phase accumulation |
+| **Total** | **197°** | | |
+
+**Why 98 + 99?** The near-equality of local (98) and global (99) contributions suggests a geometric balance between fiber structure and base topology. The slight asymmetry (99 > 98) may relate to CP violation being near-maximal within the allowed geometric range.
+
+**Alternative form**:
+$$\delta_{CP} = (b_2 + b_3) + H^* = 98 + 99 = 197°$$
+
+This reveals δ_CP as a sum over cohomological degrees.
+
+### 7.3 Falsification Timeline
+
+| Experiment | Timeline | Precision | Status |
+|------------|----------|-----------|--------|
+| T2K + NOνA | 2024 | ±24° | Current best |
+| Hyper-Kamiokande | 2034+ | ±10° | Under construction |
+| DUNE | 2034-2039 | ±5° | Under construction |
+| Combined (2040) | — | ±3° | Projected |
+
+**Decisive test criteria**:
+- Measurement δ_CP < 182° or δ_CP > 212° at 3σ → **GIFT refuted**
+- Measurement within 192°–202° at 3σ → **Strong confirmation**
+- Measurement within 182°–212° at 3σ → **Consistent, not decisive**
+
+### 7.4 Why This Prediction Matters
+
+Unlike sin²θ_W or Q_Koide which are already measured precisely, δ_CP has large experimental uncertainty (±24°). The GIFT prediction of exactly 197° is:
+
+1. **Sharp**: An integer value, not a fitted decimal
+2. **Central**: Falls in the middle of current allowed range
+3. **Testable**: DUNE will resolve to ±5° within 15 years
+
+A single experiment can confirm or refute this prediction definitively.
 
 **Status**: PROVEN (Lean verified). See S2 Section 13 for complete derivation.
 
@@ -512,7 +566,7 @@ The torsion inverse 61 = dim(F₄) + N_gen² = 52 + 9 links to exceptional algeb
 | m_tau/m_e | 7 + 10 x 248 + 10 x 99 | 3477 | 3477.15 +/- 0.05 | **0.0043%** |
 | m_mu/m_e | 27^phi | 207.01 | 206.768 | **0.118%** |
 
-The tau-electron mass ratio 3477 = 3 x 19 x 61 = N_gen x prime(8) x kappa_T^(-1) exhibits remarkable factorization into framework constants.
+The tau-electron mass ratio 3477 = 3 × 19 × 61 = N_gen × prime(8) × κ_T⁻¹ factorizes into framework constants.
 
 ### 9.3 Quark Sector
 
@@ -828,10 +882,11 @@ E₈×E₈ algebra  ←→  ?  ←→  G₂ holonomy  ←→  ?  ←→  SM para
 
 ### 17.3 Experimental Priorities
 
-1. **DUNE (2028-2030)**: delta_CP measurement (decisive)
-2. **FCC-ee (2040+)**: sin^2(theta_W) precision
-3. **Tau factories**: Q_Koide to higher precision
-4. **Lattice QCD**: m_s/m_d convergence
+1. **DUNE (2034-2039)**: δ_CP measurement to ±5° (decisive)
+2. **Hyper-Kamiokande (2034+)**: Independent δ_CP measurement
+3. **FCC-ee (2040+)**: sin²θ_W precision
+4. **Tau factories**: Q_Koide to higher precision
+5. **Lattice QCD**: m_s/m_d convergence
 
 ---
 


### PR DESCRIPTION
- Harmonize DUNE timeline to 2034-2039 across all documents
- Add Part 0 (Octonionic Foundation) to S1 for clearer structure
- Expand Section 7 (CP violation) with physical interpretation and falsification criteria
- Enrich Section 4.2 with explicit epistemic claims and limitations
- Clarify S3 Section 4: torsion components are theoretical exploration, not predictions
- Correct δ_CP formula display: 98+99 → 7×14+99 to show structure
- Uniformize κ_T notation
- Tone: remove marketing language ("remarkable" → neutral)