### PR TITLE
Complete torsion framing fix: remove remaining T_analytical claims

### DIFF
--- a/publications/markdown/GIFT_v3.2_S1_foundations.md
+++ b/publications/markdown/GIFT_v3.2_S1_foundations.md
@@ -487,14 +487,14 @@ $$\det(g) = \frac{\text{Weyl} \times (\text{rank}(E_8) + \text{Weyl})}{2^{\text{
 
 ## 11. Formal Certification
 
-### 11.1 The Analytical Solution
+### 11.1 The Algebraic Reference Form
 
-The G₂ metric on K₇ is exactly:
+The algebraic reference form in a local G₂-adapted orthonormal coframe:
 
-$$\varphi = c \cdot \varphi_0, \quad c = \left(\frac{65}{32}\right)^{1/14}$$
-$$g = c^2 \cdot I_7 = \left(\frac{65}{32}\right)^{1/7} \cdot I_7$$
+$$\varphi_{\text{ref}} = c \cdot \varphi_0, \quad c = \left(\frac{65}{32}\right)^{1/14}$$
+$$g_{\text{ref}} = c^2 \cdot I_7 = \left(\frac{65}{32}\right)^{1/7} \cdot I_7$$
 
-**Important clarification**: This metric representation holds in a local G₂-adapted orthonormal frame. The manifold K₇ constructed via TCS is curved and compact; "I₇" reflects the frame choice, not global flatness.
+**Important clarification**: This representation holds in a local orthonormal frame. The manifold K₇ constructed via TCS is curved and compact; "I₇" reflects the frame choice, not global flatness. The reference form φ_ref determines det(g) = 65/32; the global torsion-free solution φ_TF exists by Joyce's theorem.
 
 | Property | Value | Status |
 |----------|-------|--------|

--- a/publications/markdown/GIFT_v3.2_S3_dynamics.md
+++ b/publications/markdown/GIFT_v3.2_S3_dynamics.md
@@ -147,25 +147,25 @@ $$61 = b_3 - b_2 + \text{Weyl} = 77 - 21 + 5$$
 
 $$61 = \text{prime}(18)$$
 
-### 2.3 Critical Distinction: Capacity vs Realized Value
+### 2.3 Critical Distinction: Capacity vs Base Solution
 
 ┌─────────────────────────────────────────────────────────────┐
 │  **IMPORTANT**                                              │
 │                                                             │
-│  kappa_T = 1/61 is the CAPACITY, the maximum torsion that   │
-│  K₇ topology permits while preserving G₂ holonomy.         │
+│  κ_T = 1/61 is the CAPACITY, the maximum torsion that       │
+│  K₇ topology permits while preserving G₂ holonomy.          │
 │                                                             │
-│  T_analytical = 0 is the REALIZED value for the exact      │
-│  solution φ = (65/32)^{1/14} × φ₀.                         │
+│  Joyce's theorem guarantees a torsion-free metric exists    │
+│  on K₇ (i.e., T = 0 for that metric, by definition).        │
 │                                                             │
-│  The capacity 1/61 characterizes the manifold.             │
-│  The realized value 0 characterizes the specific metric.   │
+│  The capacity 1/61 characterizes the manifold's topology.   │
+│  The torsion-free solution exists by Joyce's theorem.       │
 │                                                             │
-│  All 18 predictions use topology (via b₂, b₃, dim_G₂),     │
-│  NOT the realized torsion value.                           │
+│  All 18 predictions use topology (via b₂, b₃, dim_G₂),      │
+│  NOT the realized torsion value.                            │
 └─────────────────────────────────────────────────────────────┘
 
-**Status**: TOPOLOGICAL (capacity, not realized value)
+**Status**: TOPOLOGICAL (capacity bounds deviations from torsion-free base)
 
 ### 2.4 Compatibility with Cosmological Constraints
 


### PR DESCRIPTION
Addresses remaining issues identified in review:
- S3 Section 2.3: Replace "T_analytical = 0 realized for exact solution" with Joyce's theorem framing
- S1 Section 11.1: Rename "Analytical Solution" to "Algebraic Reference Form" and clarify that φ_TF exists by Joyce, not by global constancy

Key principle: T = 0 is guaranteed by Joyce's theorem for the torsion-free metric φ_TF, not by claiming φ_ref = c·φ₀ is globally constant on K₇.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shifts torsion discussion to a Joyce-theorem-based framing and clarifies the role of the algebraic reference form.
> 
> - S1 §11.1 renamed to **“The Algebraic Reference Form”**; equations now use `φ_ref` and `g_ref`, with explicit note that the form is local in an orthonormal coframe, determines `det(g)=65/32`, and that a torsion-free solution `φ_TF` exists by Joyce (not by global constancy)
> - S3 §2.3 retitled to emphasize **capacity vs base solution**; boxed text rewritten to state `κ_T = 1/61` is a topological capacity and that torsion-free existence follows from Joyce; removes prior "T_analytical = 0" language, updates status line, and standardizes notation to `κ_T`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f3d6205b3ec910f15f128a01e6cf1af4f1ad528. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->