### PR TITLE
Add Fano plane section and fix C(7,2) error

### DIFF
--- a/publications/markdown/GIFT_v3.2_S1_foundations.md
+++ b/publications/markdown/GIFT_v3.2_S1_foundations.md
@@ -62,7 +62,7 @@ The pattern terminates at 𝕆. There is no 16-dimensional normed division algeb
 
 | Property | Value | GIFT Role |
 |----------|-------|-----------|
-| dim(G₂) | 14 = C(7,2) | Q_Koide numerator |
+| dim(G₂) | 14 = C(7,2) − C(7,1) = 21 − 7 | Q_Koide numerator |
 | Action | Transitive on S⁶ ⊂ Im(𝕆) | Connects all directions |
 | Embedding | G₂ ⊂ SO(7) | Preserves φ₀ |
 
@@ -74,6 +74,22 @@ This is not a choice. It is a consequence:
 - A compact 7-manifold with G₂ holonomy is the geometric realization
 
 **K₇ is to G₂ what the circle is to U(1).**
+
+### 0.4 The Fano Plane: Combinatorial Structure of Im(𝕆)
+
+The 7 imaginary octonion units form the **Fano plane** PG(2,2), the smallest projective plane:
+- 7 points (imaginary units e₁...e₇)
+- 7 lines (multiplication triples eᵢ × eⱼ = ±eₖ)
+- 3 points per line
+
+**Combinatorial counts**:
+- Point-line incidences: 7 × 3 = 21 = C(7,2) = b₂
+- Automorphism group: PSL(2,7) with |PSL(2,7)| = 168
+
+**Numerical observation**: The following identity holds:
+$$(b_3 + \dim(G_2)) + b_3 = 91 + 77 = 168 = |{\rm PSL}(2,7)| = {\rm rank}(E_8) \times b_2$$
+
+Whether this arithmetic coincidence reflects deeper geometric structure connecting gauge and matter sectors remains an open question.
 
 ---
 

--- a/publications/markdown/GIFT_v3.2_main.md
+++ b/publications/markdown/GIFT_v3.2_main.md
@@ -193,7 +193,7 @@ This answers the "selection principle" question: K7 is not chosen from a landsca
 
 Mathematical properties:
 
-**Dimension**: dim(G₂) = 14 = C(7,2), counting pairs of imaginary octonion units. This number appears directly in predictions (Q_Koide = 14/21).
+**Dimension**: dim(G₂) = 14 = C(7,2) − 7, the number of pairs minus the number of units. This number appears directly in predictions (Q_Koide = 14/21).
 
 **Characterization**: G₂ holonomy is equivalent to existence of a parallel 3-form φ satisfying dφ = 0 and d*φ = 0, where * denotes Hodge duality.
 
@@ -825,6 +825,19 @@ The topological foundations rest on established mathematics. The TCS constructio
 - Variational principle on G₂ moduli space
 - Calibrated geometry constraints
 - K-theory classification
+
+**Observed pattern (v3.2)**: Formula constants exhibit a mod-7 regularity:
+
+| Divisible by 7 | ≡ 1 (mod 7) |
+|----------------|-------------|
+| b₂ = 21 | H* = 99 |
+| b₃ = 77 | rank(E₈) = 8 |
+| dim(G₂) = 14 | δ_CP = 1 |
+| 91 = b₃ + dim(G₂) | |
+
+One speculative interpretation: quantities divisible by 7 count local (fiber-level) degrees of freedom, while those ≡ 1 (mod 7) involve global (base-level) contributions including the cohomological unit b₀ = 1.
+
+This pattern, if not coincidental, might constrain which combinations of topological invariants appear in physical observables. No derivation of this selection principle currently exists.
 
 ### 15.2 Dimensional Quantities
 


### PR DESCRIPTION
- Fix incorrect claim dim(G₂) = 14 = C(7,2) → correct: 14 = C(7,2) − 7
- Add §0.4 "The Fano Plane" in S1 with humble framing
- Add mod-7 pattern observation in Main §15.1 as speculative

All additions use hedged language per documentation guidelines.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs updates (v3.2)**
> 
> - Fixes the combinatorial identity for `dim(G₂)` to `14 = C(7,2) − 7` in S1 and Main, aligning Koide-related counts.
> - Adds S1 §0.4 “The Fano Plane,” linking octonion units to PG(2,2) with counts (`b₂ = 21`, `|PSL(2,7)| = 168`) and a noted arithmetic identity `(b₃ + dim(G₂)) + b₃ = 168` (framed as observational/speculative).
> - Introduces a mod‑7 regularity table in Main §15.1 highlighting which constants are multiples of 7 vs ≡ 1 (mod 7), explicitly labeled as speculative.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4d86ddf31a54ecb447086911a555147779c23dfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->