### PR TITLE
Harmonize PROVEN format to Lean 4 across all documents

### DIFF
--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -12,7 +12,7 @@ A compact 7-dimensional Riemannian manifold with G₂ holonomy. The subscript 7 
 
 ### Status Classifications
 Framework uses hierarchical classification for results:
-- **PROVEN (Lean)**: Formally verified by Lean 4 kernel with Mathlib (machine-checked proofs, zero domain axioms, zero sorry)
+- **PROVEN (Lean 4)**: Formally verified by Lean 4 kernel with Mathlib (machine-checked proofs, zero domain axioms, zero sorry)
 - **PROVEN**: Exact topological identity with rigorous mathematical proof
 - **TOPOLOGICAL**: Direct consequence of topological structure
 - **DERIVED**: Calculated from proven relations

--- a/publications/markdown/GIFT_v3.2_S1_foundations.md
+++ b/publications/markdown/GIFT_v3.2_S1_foundations.md
@@ -161,7 +161,7 @@ $$|W(E_8)| = p_2^{\dim(G_2)} \times N_{gen}^{Weyl} \times Weyl^{p_2} \times \dim
 | 5² | p₂ = 2 | 25 | Weyl^(binary) |
 | 7¹ | 1 | 7 | dim(K₇) |
 
-**Status**: **PROVEN (Lean)**: `weyl_E8_topological_factorization`
+**Status**: **PROVEN (Lean 4)**: `weyl_E8_topological_factorization`
 
 ---
 
@@ -239,7 +239,7 @@ where g(6) = 6, g(7) = rank(E₈) = 8, g(8) = D_bulk = 11.
 - E₇: 7 × 19 = 133 ✓
 - E₈: 8 × 31 = 248 ✓
 
-**Status**: **PROVEN (Lean)**: `exceptional_chain_certified`
+**Status**: **PROVEN (Lean 4)**: `exceptional_chain_certified`
 
 ---
 
@@ -258,7 +258,7 @@ where g(6) = 6, g(7) = rank(E₈) = 8, g(8) = D_bulk = 11.
 The hierarchy parameter numerator:
 $$\tau_{num} = 3472 = 7 \times 496 = \dim(K_7) \times \dim(E_8 \times E_8)$$
 
-**Status**: **PROVEN (Lean)**: `tau_num_E8xE8`
+**Status**: **PROVEN (Lean 4)**: `tau_num_E8xE8`
 
 ### 4.3 Binary Duality Parameter
 
@@ -294,7 +294,7 @@ $$\dim(F_4) = 52 = p_2^2 \times \alpha_{sum}^B = 4 \times 13$$
 | dim(F₄) - dim(J₃(O)) | 25 = 5² | Weyl² |
 | dim(E₆) - dim(F₄) | 26 | dim(J₃(O)₀) |
 
-**Status**: **PROVEN (Lean)**: `exceptional_differences_certified`
+**Status**: **PROVEN (Lean 4)**: `exceptional_differences_certified`
 
 ---
 
@@ -365,7 +365,7 @@ $$\kappa_T^{-1} = 61 = \dim(F_4) + N_{gen}^2 = 52 + 9$$
 Alternative:
 $$61 = \Pi(\alpha^2_B) + 1 = 2 \times 5 \times 6 + 1$$
 
-**Status**: **PROVEN (Lean)**: `kappa_T_inv_decomposition`
+**Status**: **PROVEN (Lean 4)**: `kappa_T_inv_decomposition`
 
 ---
 

--- a/publications/markdown/GIFT_v3.2_S2_derivations.md
+++ b/publications/markdown/GIFT_v3.2_S2_derivations.md
@@ -68,7 +68,7 @@ Before presenting derivations, we clarify the logical structure:
 | Status | Criterion |
 |--------|-----------|
 | **PROVEN** | Complete mathematical proof, exact result from topology |
-| **PROVEN (Lean)** | Verified by Lean 4 kernel with Mathlib (machine-checked) |
+| **PROVEN (Lean 4)** | Verified by Lean 4 kernel with Mathlib (machine-checked) |
 | **TOPOLOGICAL** | Direct consequence of manifold structure |
 
 ## 2. Notation

--- a/publications/markdown/GIFT_v3.2_S3_dynamics.md
+++ b/publications/markdown/GIFT_v3.2_S3_dynamics.md
@@ -694,7 +694,7 @@ $$3477 = 3 \times 19 \times 61 = N_{gen} \times \text{prime}(8) \times \kappa_T^
 **Experimental**: 1776.86 MeV
 **Deviation**: 0.004%
 
-**Status**: PROVEN (Lean verified)
+**Status**: PROVEN (Lean 4)
 
 ### 15.4 Lepton Summary
 

--- a/publications/markdown/GIFT_v3.2_main.md
+++ b/publications/markdown/GIFT_v3.2_main.md
@@ -169,7 +169,7 @@ This derivation admits alternative forms. The ratio b2/dim(K7) = 21/7 = 3 gives 
 
 The experimental status is unambiguous: no fourth generation has been observed at the LHC despite searches to the TeV scale.
 
-**Status**: PROVEN (Lean verified)
+**Status**: PROVEN (Lean 4)
 
 **Note on Lean verification**: Lean 4 establishes arithmetic consistency and symbolic correctness of the derived relations. It verifies that given the topological inputs (b₂=21, b₃=77, dim(G₂)=14), the algebraic identities hold exactly. It does not constitute a proof of geometric existence or physical validity.
 
@@ -420,7 +420,7 @@ $$\sin^2\theta_W = \frac{b_2}{b_3 + \dim(G_2)} = \frac{21}{91} = \frac{3}{13} = 
 
 **Interpretation**: b₂ counts gauge moduli; b₃ + dim(G₂) counts matter + holonomy degrees of freedom. The ratio measures gauge-matter coupling geometrically.
 
-**Status**: PROVEN (Lean verified). See S2 Section 7 for complete derivation.
+**Status**: PROVEN (Lean 4). See S2 Section 7 for complete derivation.
 
 ---
 
@@ -482,7 +482,7 @@ GIFT is the only framework where Q = 2/3 follows from pure algebra with no fitti
 
 If the Koide relation truly equals 2/3 exactly, improved measurements of lepton masses should converge toward this value. Current experimental uncertainty is dominated by the tau mass. Future precision measurements at tau-charm factories could test whether deviations from 2/3 are real or reflect measurement limitations.
 
-**Status**: PROVEN (Lean verified)
+**Status**: PROVEN (Lean 4)
 
 ---
 
@@ -536,7 +536,7 @@ Unlike sin²θ_W or Q_Koide which are already measured precisely, δ_CP has larg
 
 A single experiment can confirm or refute this prediction definitively.
 
-**Status**: PROVEN (Lean verified). See S2 Section 13 for complete derivation.
+**Status**: PROVEN (Lean 4). See S2 Section 13 for complete derivation.
 
 ---
 


### PR DESCRIPTION
- Standardize 'PROVEN (Lean)' and 'PROVEN (Lean verified)' → 'PROVEN (Lean 4)'
- Update S1, S2, S3, Main, and GLOSSARY.md
- Legacy/CHANGELOG files preserved (historical records)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies the formal verification status wording to a single label.
> 
> - Standardizes status text to `PROVEN (Lean 4)` across `GLOSSARY.md`, `GIFT_v3.2_S1_foundations.md`, `GIFT_v3.2_S2_derivations.md`, `GIFT_v3.2_S3_dynamics.md`, and `GIFT_v3.2_main.md`
> - No mathematical content, formulas, or structures changed; edits are wording-only in status lines
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 281c7d9cacadb8ade27397b11589505e12ca3b18. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->