### PR TITLE
Sync core version references from v3.1.12 to v3.2.0

### DIFF
--- a/CITATION.md
+++ b/CITATION.md
@@ -134,12 +134,12 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 ## Formal Verification
 
 ```bibtex
-@software{gift_core_v3112,
+@software{gift_core_v320,
   title   = {GIFT Core: Formal Verification in Lean 4 + Coq},
   author  = {de La Fournière, Brieuc},
   year    = {2025},
   url     = {https://github.com/gift-framework/core},
-  version = {3.1.12},
+  version = {3.2.0},
   note    = {185 relations verified, 40 axioms, K₇ metric pipeline, Joyce existence theorem}
 }
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 | **Precision** | 0.24% mean deviation across 18 dimensionless predictions (PDG 2024) |
 | **Uniqueness** | #1 out of 54,327 configurations tested (>4σ significance) |
 | **Parameters** | Zero adjustable (all structurally determined) |
-| **Verified** | 185 relations proven in Lean 4 + Coq (40 axioms, core v3.1.12) |
+| **Verified** | 185 relations proven in Lean 4 + Coq (40 axioms, core v3.2.0) |
 | **Exact results** | sin²θ_W = 3/13 · τ = 3472/891 · det(g) = 65/32 · Monster = 47×59×71 |
 
 **Dimensional reduction:** E₈×E₈ (496D) → AdS₄ × K₇ (11D) → Standard Model (4D)

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -80,7 +80,7 @@ GIFT/
 ## Version
 
 **Current**: v3.2.0 (2026-01-05)
-**Relations**: 185 certified (core v3.1.12)
+**Relations**: 185 certified (core v3.2.0)
 **Predictions**: 18 dimensionless (**0.24% mean deviation, PDG 2024**)
 **Monte Carlo**: 54,327 configurations tested, 0 better than GIFT
 **Key Result**: Analytical G₂ metric with T = 0 exactly

--- a/publications/README.md
+++ b/publications/README.md
@@ -92,7 +92,7 @@ See [validation_v32.py](../statistical_validation/validation_v32.py) for methodo
 
 ## Formal Verification
 
-**185 relations verified** in Lean 4 + Coq (core v3.1.12).
+**185 relations verified** in Lean 4 + Coq (core v3.2.0).
 
 See [gift-framework/core](https://github.com/gift-framework/core) for proofs.
 

--- a/publications/markdown/GIFT_v3.2_S1_foundations.md
+++ b/publications/markdown/GIFT_v3.2_S1_foundations.md
@@ -6,7 +6,7 @@
 
 *Complete mathematical foundations for GIFT, presenting E8 architecture and K7 manifold construction.*
 
-**Lean Verification**: 185 relations, 40 axioms (core v3.1.12)
+**Lean Verification**: 185 relations, 40 axioms (core v3.2.0)
 
 ---
 
@@ -119,7 +119,7 @@ $$\frac{1}{2}(\pm 1, \pm 1, \pm 1, \pm 1, \pm 1, \pm 1, \pm 1, \pm 1)$$
 
 **Verification**: 112 + 128 = 240 roots, all length √2.
 
-**Lean Status (v3.1.12)**: E₈ Root System **12/12 COMPLETE** — All theorems proven:
+**Lean Status (v3.2.0)**: E₈ Root System **12/12 COMPLETE** — All theorems proven:
 - `D8_roots_card` = 112, `HalfInt_roots_card` = 128
 - `E8_roots_card` = 240, `E8_roots_decomposition`
 - `E8_inner_integral`, `E8_norm_sq_even`, `E8_sub_closed`
@@ -310,7 +310,7 @@ $$\dim(F_4) = 52 = p_2^2 \times \alpha_{sum}^B = 4 \times 13$$
 | rank(G₂) | 2 | Lie rank |
 | Definition | Aut(O) | Octonion automorphisms |
 
-**Lean Status (v3.1.12)**: G₂ Cross Product **9/11** proven:
+**Lean Status (v3.2.0)**: G₂ Cross Product **9/11** proven:
 - `epsilon_antisymm`, `epsilon_diag`, `cross_apply` ✓
 - `G2_cross_bilinear`, `G2_cross_antisymm`, `cross_self` ✓
 - `G2_cross_norm` (Lagrange identity ‖u×v‖² = ‖u‖²‖v‖² − ⟨u,v⟩²) ✓
@@ -667,7 +667,7 @@ This supplement establishes the mathematical foundations:
 - **Weyl Triple Identity**: Weyl = 5 from three independent derivations
 - Exceptional chain theorem
 - Octonionic structure
-- **Lean v3.1.12**: E₈ root system 12/12 complete, `E8_basis_generates` now THEOREM
+- **Lean v3.2.0**: E₈ root system 12/12 complete, `E8_basis_generates` now THEOREM
 
 **Part II - G₂ Holonomy**:
 - Torsion conditions

--- a/publications/markdown/GIFT_v3.2_main.md
+++ b/publications/markdown/GIFT_v3.2_main.md
@@ -803,7 +803,7 @@ Unlike many approaches to fundamental physics, GIFT makes sharp, testable predic
 
 ### 14.4 Mathematical Rigor
 
-The topological foundations rest on established mathematics. The TCS construction follows Joyce, Kovalev, and collaborators. The index theorem derivation of N_gen = 3 is standard. 185 relations have been verified in Lean 4 (core v3.1.12), providing machine-checked confirmation of algebraic claims. The E₈ root system is fully proven (12/12 theorems), including `E8_basis_generates` now a theorem rather than axiom.
+The topological foundations rest on established mathematics. The TCS construction follows Joyce, Kovalev, and collaborators. The index theorem derivation of N_gen = 3 is standard. 185 relations have been verified in Lean 4 (core v3.2.0), providing machine-checked confirmation of algebraic claims. The E₈ root system is fully proven (12/12 theorems), including `E8_basis_generates` now a theorem rather than axiom.
 
 ---
 


### PR DESCRIPTION
Update all documentation to reference gift-framework/core v3.2.0:
- README.md
- STRUCTURE.md
- CITATION.md
- publications/README.md
- publications/markdown/GIFT_v3.2_main.md
- publications/markdown/GIFT_v3.2_S1_foundations.md

Core v3.2.0 includes:
- TCS building blocks for both Betti number derivations
- Structural identities (Weyl Triple, PSL(2,7))
- 185 certified relations