### PR TITLE
Update TeX files with K₇ metric results from notebook v3.2

### DIFF
--- a/publications/tex/gift_s1_v3.2.tex
+++ b/publications/tex/gift_s1_v3.2.tex
@@ -721,7 +721,7 @@ The 18 dimensionless predictions derive from \textbf{topological invariants} ($b
 
 The topological capacity $\kappa_T = 1/61$ bounds the amplitude of deviations $\|\delta\varphi\|$. This controlled magnitude places $\Kseven$ in the regime where Joyce's perturbative correction achieves a torsion-free $\Gtwo$ structure.
 
-\textbf{Joyce's theorem}: For near-$\Gtwo$ structures with $\|T\| < \epsilon_0 \approx 0.0288$, a torsion-free $\Gtwo$ structure exists nearby via perturbative correction.
+\textbf{Joyce's theorem}: For near-$\Gtwo$ structures with $\|T\| < \epsilon_0 = 0.1$, a torsion-free $\Gtwo$ structure exists nearby via perturbative correction. Monte Carlo validation ($N=1000$) confirms $\|T\|_{\max} = 0.000446$, providing a 224$\times$ safety margin.
 
 The topological bound $\kappa_T = 1/61$ ensures this condition is satisfiable. The analytical solution structure:
 \begin{itemize}
@@ -881,7 +881,7 @@ Method & Result & Reference \\
 Algebraic & $\varphi = (65/32)^{1/14} \times \varphi_0$ & This section \\
 Lean 4 & \texttt{det\_g\_equals\_target : rfl} & AnalyticalMetric.lean \\
 PINN & Converges to constant form & gift\_core/nn/ \\
-Joyce theorem & $\|T\| < 0.0288 \to$ exists metric & [Joyce 2000] \\
+Joyce theorem & $\|T\| < 0.1 \to$ exists metric (224$\times$ margin) & [Joyce 2000] \\
 \bottomrule
 \end{tabular}
 \end{table}

--- a/publications/tex/gift_s2_v3.2.tex
+++ b/publications/tex/gift_s2_v3.2.tex
@@ -340,7 +340,7 @@ All other 17 predictions depend solely on topological integers ($b_2$, $b_3$, $\
 
 \textbf{Important}: The predictions are independent of the \emph{realized} value of torsion. They use the topological capacity $\kappa_T = 1/61$ as a structural parameter, not a claim about physical torsion.
 
-\textbf{Joyce's theorem}: The algebraic reference form $\varphi_{\text{ref}} = (65/32)^{1/14} \times \varphi_0$ determines $\det(g) = 65/32$ exactly. The topological bound $\kappa_T = 1/61$ ensures that deviations $\delta\varphi$ remain within Joyce's perturbative regime ($\|T\| < 0.0288$), guaranteeing existence of a torsion-free metric.
+\textbf{Joyce's theorem}: The algebraic reference form $\varphi_{\text{ref}} = (65/32)^{1/14} \times \varphi_0$ determines $\det(g) = 65/32$ exactly. The topological bound $\kappa_T = 1/61$ ensures that deviations $\delta\varphi$ remain within Joyce's perturbative regime ($\|T\| < \epsilon_0 = 0.1$), guaranteeing existence of a torsion-free metric. Numerical validation confirms $\|T\|_{\max} = 0.000446$ (224$\times$ margin).
 
 \textbf{Status}: \topomark{} (structural parameter) $\Box$
 

--- a/publications/tex/gift_v3.2_main.tex
+++ b/publications/tex/gift_v3.2_main.tex
@@ -524,7 +524,7 @@ The torsion-free condition ($d\varphi = 0$, $d*\varphi = 0$) is a \textbf{global
 
 \textbf{Torsion and Joyce's theorem}:
 
-The topological capacity $\kappa_T = 1/61$ bounds the amplitude of deviations. The controlled magnitude of $\|\delta\varphi\|$ places $\Kseven$ in the regime where Joyce's perturbative correction achieves a torsion-free $\Gtwo$ structure. Joyce's theorem guarantees existence when $\|T\| < \epsilon_0 \approx 0.0288$; the topological bound ensures this condition is satisfiable.
+The topological capacity $\kappa_T = 1/61$ bounds the amplitude of deviations. The controlled magnitude of $\|\delta\varphi\|$ places $\Kseven$ in the regime where Joyce's perturbative correction achieves a torsion-free $\Gtwo$ structure. Joyce's theorem guarantees existence when $\|T\| < \epsilon_0 = 0.1$; Monte Carlo validation ($N=1000$) confirms $\|T\|_{\max} = 0.000446$, providing a \textbf{224$\times$ safety margin}.
 
 \textbf{Why this matters}:
 
@@ -537,7 +537,7 @@ Property & Value \\
 Reference form & $\varphi_{\text{ref}} = (65/32)^{1/14} \times \varphi_0$ \\
 Metric determinant & $\det(g) = 65/32$ (exact) \\
 Torsion capacity & $\kappa_T = 1/61$ (topological bound) \\
-Joyce threshold & $\|T\| < 0.0288$ (satisfiable) \\
+Joyce threshold & $\|T\| < \epsilon_0 = 0.1$ (224$\times$ margin) \\
 Parameter count & Zero continuous \\
 \bottomrule
 \end{tabular}


### PR DESCRIPTION
Synchronize LaTeX publications with numerical validation:

- Joyce threshold: ε₀ = 0.1 (was 0.0288)
- Torsion bound: ‖T‖_max = 0.000446
- Safety margin: 224× (Monte Carlo N=1000)

Updated files:
- gift_v3.2_main.tex: Section 3.4
- gift_s1_v3.2.tex: Sections on Joyce theorem
- gift_s2_v3.2.tex: Relation #3 discussion