### PR TITLE
Update S1 and S3 references from 18 to 33 observables

### DIFF
--- a/publications/markdown/GIFT_v3.3_S1_foundations.md
+++ b/publications/markdown/GIFT_v3.3_S1_foundations.md
@@ -42,7 +42,7 @@ K₇ with G₂ holonomy (unique compact realization)
 Topological invariants (b₂ = 21, b₃ = 77)
     │
     ▼
-18 dimensionless predictions
+33 dimensionless predictions
 ```
 
 ### 0.1 The Division Algebra Chain
@@ -366,7 +366,7 @@ $$\nabla\phi = 0 \Leftrightarrow d\phi = 0 \text{ and } d*\phi = 0$$
 | φ_ref | Algebraic reference form | c × φ₀ |
 | T_realized | Actual torsion for global solution | Constrained by Joyce |
 
-**Key insight**: The 18 dimensionless predictions use only topological invariants (b₂, b₃, dim(G₂)) and are independent of the specific torsion realization. The value κ_T = 1/61 defines the geometric bound on deviations from φ_ref.
+**Key insight**: The 33 dimensionless predictions use only topological invariants (b₂, b₃, dim(G₂)) and are independent of the specific torsion realization. The value κ_T = 1/61 defines the geometric bound on deviations from φ_ref.
 
 **Physical interactions**: Emerge from the geometry of K₇, with deviations δφ from the reference form bounded by topological constraints. This mechanism is THEORETICAL (see S3 for details).
 

--- a/publications/markdown/GIFT_v3.3_S3_dynamics.md
+++ b/publications/markdown/GIFT_v3.3_S3_dynamics.md
@@ -58,7 +58,7 @@ All results emerge from the topological structure established in S1.
 - Sections 9-13 (scale bridge): Working conjecture, 0.09% precision
 - Sections 19-24 (cosmology): Exploratory connections
 
-**The 18 dimensionless predictions (S2) do not depend on any content in this supplement.**
+**The 33 dimensionless predictions (S2) do not depend on any content in this supplement.**
 
 ---
 
@@ -161,7 +161,7 @@ $$61 = \text{prime}(18)$$
 │  The capacity 1/61 characterizes the manifold's topology.   │
 │  The torsion-free solution exists by Joyce's theorem.       │
 │                                                             │
-│  All 18 predictions use topology (via b₂, b₃, dim_G₂),      │
+│  All 33 predictions use topology (via b₂, b₃, dim_G₂),      │
 │  NOT the realized torsion value.                            │
 └─────────────────────────────────────────────────────────────┘
 
@@ -227,7 +227,7 @@ The small but non-zero torsion enables:
 │  bounded by κ_T = 1/61.                                     │
 │                                                             │
 │  These are theoretical explorations, NOT predictions.       │
-│  The 18 dimensionless predictions (S2) do not use these     │
+│  The 33 dimensionless predictions (S2) do not use these     │
 │  values.                                                    │
 └─────────────────────────────────────────────────────────────┘
 


### PR DESCRIPTION
S1_foundations:
- Line 45: Update chain diagram to "33 dimensionless predictions"
- Line 369: Update key insight text

S3_dynamics:
- Line 61: Update disclaimer about S2 independence
- Line 164: Update prediction count in info box
- Line 230: Update prediction count in info box