### PR TITLE
Fix critical terminology and consistency errors

### DIFF
--- a/docs/OBSERVABLE_REFERENCE.md
+++ b/docs/OBSERVABLE_REFERENCE.md
@@ -41,7 +41,7 @@
 | b_2 | 21 | Second Betti number | **0** | 3x7 |
 | dim(J_3(O)) | 27 | Exceptional Jordan algebra | 6 | - |
 | det(g)_den | 32 | Metric determinant denominator | 4 | 2^5 |
-| chi(K_7) | 42 | Euler characteristic | **0** | 6x7 |
+| 2b_2 | 42 | Structural constant (= p₂ × b₂) | **0** | 6x7 |
 | dim(F_4) | 52 | F_4 dimension | 3 | - |
 | fund(E_7) | 56 | E_7 fundamental representation | **0** | 8x7 |
 | kappa_T^-1 | 61 | Inverse torsion capacity | 5 | prime |
@@ -61,7 +61,7 @@ b_2            = N_gen x dim(K_7)         = 3 x 7   = 21
 b_3 + dim(G_2) = dim(K_7) x alpha_sum     = 7 x 13  = 91
 alpha_sum      = rank(E_8) + Weyl         = 8 + 5   = 13
 D_bulk         = rank(E_8) + N_gen        = 8 + 3   = 11
-chi(K_7)       = p_2 x b_2                = 2 x 21  = 42
+2b_2           = p_2 x b_2                = 2 x 21  = 42  (structural constant)
 H*             = b_2 + b_3 + 1            = 21+77+1 = 99
 
 PSL(2,7) = 168 = rank(E_8) x b_2          = 8 x 21
@@ -116,7 +116,7 @@ Each observable receives a classification based on the number of independent alg
 |---|------------|--------------|-------|------|------|---------|--------|
 | 9 | **m_s/m_d** | (alpha_sum+dim_J3O)/p_2 | 40/2 = 20 | 20.0 | 0.00% | 14 | ROBUST |
 | 10 | **m_c/m_s** | (dim_E8-p_2)/b_2 | 246/21 = 11.71 | 11.7 | 0.12% | 5 | SUPPORTED |
-| 11 | **m_b/m_t** | 1/chi(K_7) | 1/42 = 0.0238 | 0.024 | 0.79% | 12 | ROBUST |
+| 11 | **m_b/m_t** | 1/(2b₂) | 1/42 = 0.0238 | 0.024 | 0.79% | 12 | ROBUST |
 | 12 | **m_u/m_d** | (1+dim_E6)/PSL_27 | 79/168 = 0.470 | 0.47 | 0.05% | 4 | DERIVED |
 
 ### 3.5 Neutrino/PMNS Sector
@@ -163,7 +163,7 @@ Each observable receives a classification based on the number of independent alg
 | 26 | **m_H/m_W** | (N_gen+dim_E6)/dim_F4 | 81/52 = 1.5577 | 1.558 | 0.02% | 3 | DERIVED |
 | 27 | **m_W/m_Z** | (chi-Weyl)/chi | 37/42 = 0.8810 | 0.8815 | 0.06% | 8 | SUPPORTED |
 
-**Note**: m_W/m_Z = 37/42 is a **v3.3 correction**. Previous formula gave 8.7% error.
+**Note**: m_W/m_Z = 37/42 is a **v3.3 correction**. Previous formula (23/26) had 0.35% deviation; new formula achieves 0.06%.
 
 ### 4.4 Lepton Ratios Extended
 
@@ -195,9 +195,11 @@ Each observable receives a classification based on the number of independent alg
 
 **Most remarkable result**:
 
-$$\frac{\Omega_{DM}}{\Omega_b} = \frac{b_0 + \chi(K_7)}{\text{rank}(E_8)} = \frac{1 + 42}{8} = \frac{43}{8} = 5.375$$
+$$\frac{\Omega_{DM}}{\Omega_b} = \frac{b_0 + 2b_2}{\text{rank}(E_8)} = \frac{1 + 42}{8} = \frac{43}{8} = 5.375$$
 
-The ratio of dark matter to baryonic matter **explicitly contains chi(K_7) = 42**.
+The ratio of dark matter to baryonic matter **explicitly contains the structural constant 2b₂ = 42**.
+
+**Note**: The Euler characteristic χ(K₇) = 0 for any compact odd-dimensional manifold like K₇. The value 42 = p₂ × b₂ is a distinct structural constant derived from Betti numbers.
 
 ---
 
@@ -221,7 +223,7 @@ The ratio of dark matter to baryonic matter **explicitly contains chi(K_7) = 42*
 | 46 | **b_2(K_7)** | 21 | Second Betti (gauge moduli) | 3+ | DERIVED |
 | 47 | **b_3(K_7)** | 77 | Third Betti (matter modes) | 3+ | DERIVED |
 | 48 | **H*** | 99 | b_2+b_3+1 (total cohomology) | 5+ | SUPPORTED |
-| 49 | **chi(K_7)** | 42 | Euler characteristic | 3+ | DERIVED |
+| 49 | **2b₂** | 42 | Structural constant (p₂ × b₂) | 3+ | DERIVED |
 
 ### 6.3 Exceptional Algebras
 

--- a/docs/STATISTICAL_EVIDENCE.md
+++ b/docs/STATISTICAL_EVIDENCE.md
@@ -41,7 +41,7 @@ The Fano plane PG(2,2) is the smallest projective plane:
 |------------|---------|-------------|--------|
 | sin²θ_W | b₂/(b₃ + dim_G₂) | 21/91 = (3×7)/(13×7) | 3/13 ✓ |
 | Q_Koide | dim_G₂/b₂ | 14/21 = (2×7)/(3×7) | 2/3 ✓ |
-| m_b/m_t | 1/χ(K₇) | 1/42 = 1/(6×7) | 1/42 ✓ |
+| m_b/m_t | 1/(2b₂) | 1/42 = 1/(6×7) | 1/42 ✓ |
 
 **Physical interpretation**: Observables are **Fano-independent** — they don't depend on the specific 7-fold structure of the octonions.
 
@@ -53,7 +53,7 @@ $$N_{gen} = \frac{|PSL(2,7)|}{fund(E_7)} = \frac{168}{56} = 3$$
 |---------------|-----------|------------------|
 | 8 × 21 | rank(E₈) × b₂ | gauge_rank × gauge_moduli |
 | 3 × 56 | N_gen × fund(E₇) | generations × matter_rep |
-| 4 × 42 | (1+N_gen) × χ | families × Euler |
+| 4 × 42 | (1+N_gen) × 2b₂ | families × structural_const |
 
 ---
 

--- a/publications/markdown/GIFT_v3.3_S1_foundations.md
+++ b/publications/markdown/GIFT_v3.3_S1_foundations.md
@@ -592,7 +592,7 @@ $$g_{\text{ref}} = c^2 \cdot I_7 = \left(\frac{65}{32}\right)^{1/7} \cdot I_7$$
 **Actual solution structure**: The topology and geometry of K₇ impose a deformation:
 $$\varphi = \varphi_{\text{ref}} + \delta\varphi$$
 
-The torsion-free condition (dφ = 0, d*φ = 0) is a **global constraint**. Joyce's perturbation theorem guarantees existence of a torsion-free G₂ metric when the initial torsion satisfies ‖T‖ < ε₀ = 0.1. Monte Carlo validation (N=1000) confirms ‖T‖_max = 0.000446, providing a 220,000× safety margin.
+The torsion-free condition (dφ = 0, d*φ = 0) is a **global constraint**. Joyce's perturbation theorem guarantees existence of a torsion-free G₂ metric when the initial torsion satisfies ‖T‖ < ε₀ = 0.1. Monte Carlo validation (N=1000) confirms ‖T‖_max = 4.5 × 10⁻⁷, providing a 220,000× safety margin.
 
 **Why GIFT satisfies Joyce's criterion**: The topological bound κ_T = 1/61 constrains ‖δφ‖, ensuring the manifold lies within Joyce's perturbative regime where a torsion-free solution exists.
 
@@ -602,8 +602,8 @@ Physics-Informed Neural Network provides independent numerical validation:
 
 | Metric | Value | Significance |
 |--------|-------|--------------|
-| ‖T‖_max | 0.000446 | 220,000× below Joyce ε₀ |
-| ‖T‖_mean | 0.000098 | T → 0 confirmed |
+| ‖T‖_max | 4.5 × 10⁻⁷ | 220,000× below Joyce ε₀ |
+| ‖T‖_mean | ~10⁻⁸ | T → 0 confirmed |
 | Lipschitz L_eff | ~10⁻⁵ | Perturbations negligible |
 | det(g) error | < 10⁻⁶ | Confirms 65/32 |
 | Contraction K | 0.9 | Banach fixed-point applies |

--- a/publications/markdown/GIFT_v3.3_S2_derivations.md
+++ b/publications/markdown/GIFT_v3.3_S2_derivations.md
@@ -736,12 +736,14 @@ $$\lambda_H = \frac{\sqrt{\dim(G_2) + N_{gen}}}{2^{\text{Weyl}}} = \frac{\sqrt{1
 ### Relation: m_W/m_Z = 37/42 (v3.3 correction)
 
 *Formula*:
-$$\frac{m_W}{m_Z} = \frac{\chi(K_7) - \text{Weyl}}{\chi(K_7)} = \frac{42 - 5}{42} = \frac{37}{42}$$
+$$\frac{m_W}{m_Z} = \frac{2b_2 - \text{Weyl}}{2b_2} = \frac{42 - 5}{42} = \frac{37}{42}$$
 
 *Physical interpretation*:
-- χ(K₇) = 42 is the Euler characteristic
+- 2b₂ = 42 is the structural constant (= p₂ × b₂)
 - Weyl = 5 is the triple identity factor
-- The ratio involves (Euler − Weyl) / Euler
+- The ratio involves (structural_const − Weyl) / structural_const
+
+**Note**: The true Euler characteristic χ(K₇) = 0 for odd-dimensional manifolds. The constant 42 = 2b₂ is a distinct topological invariant.
 
 *Numerical value*: m_W/m_Z = 0.8810
 
@@ -1162,7 +1164,7 @@ Each prediction admits multiple algebraically independent expressions that reduc
 | 7 | m_τ/m_e | 7+10×248+10×99 | 3477 | 3477.2 | 0.004% | 3 | DERIVED |
 | 8 | m_μ/m_e | 27^φ | 207.01 | 206.77 | 0.12% | 2 | DERIVED |
 | 9 | m_s/m_d | p₂²×Weyl | 20 | 20.0 | 0.00% | 14 | ROBUST |
-| 10 | m_b/m_t | 1/χ(K₇) | 1/42 | 0.024 | 0.79% | 21 | CANONICAL |
+| 10 | m_b/m_t | 1/(2b₂) | 1/42 | 0.024 | 0.79% | 21 | CANONICAL |
 | 11 | m_u/m_d | (1+dim_E₆)/PSL₂₇ | 79/168 | 0.47 | 0.05% | 1 | SINGULAR |
 | 12 | δ_CP | dim_K₇×dim_G₂+H* | 197° | 197° | 0.00% | 3 | DERIVED |
 | 13 | θ₁₃ | π/b₂ | 8.57° | 8.54° | 0.37% | 3 | DERIVED |
@@ -1224,13 +1226,15 @@ Each prediction admits multiple algebraically independent expressions that reduc
 
 | # | Expression | Evaluation |
 |---|------------|------------|
-| 1 | b₀ / χ(K₇) | 1/42 |
+| 1 | b₀ / (2b₂) | 1/42 |
 | 2 | (b₀ + N_gen) / PSL(2,7) | 4/168 = 1/42 |
 | 3 | p₂ / (dim_K₇ + b₃) | 2/84 = 1/42 |
 | 4 | N_gen / (dim(J₃O) + H*) | 3/126 = 1/42 |
 | 5 | dim_K₇ / (dim_E₈ + dim(J₃O) + dim_K₇) | 7/294 = 1/42 |
 
-The ratio m_b/m_t = 1/42 = 1/χ(K₇) illustrates structural inevitability: the bottom-to-top mass hierarchy equals the inverse Euler characteristic of the internal manifold.
+The ratio m_b/m_t = 1/42 = 1/(2b₂) illustrates structural inevitability: the bottom-to-top mass hierarchy equals the inverse of the structural constant 2b₂ = p₂ × b₂.
+
+**Note**: The true Euler characteristic χ(K₇) = 0 for G₂ manifolds (odd-dimensional). The constant 42 is the structural invariant 2b₂.
 
 ### 24.5 The Algebraic Web
 

--- a/publications/markdown/GIFT_v3.3_main.md
+++ b/publications/markdown/GIFT_v3.3_main.md
@@ -318,7 +318,7 @@ The torsion-free condition (dφ = 0, d*φ = 0) is a **global constraint** depend
 
 **Torsion and Joyce's theorem**:
 
-The topological capacity κ_T = 1/61 bounds the amplitude of deviations. The controlled magnitude of ‖δφ‖ places K₇ in the regime where Joyce's perturbative correction achieves a torsion-free G₂ structure. Joyce's theorem guarantees existence when ‖T‖ < ε₀ = 0.1; Monte Carlo validation (N=1000) confirms ‖T‖_max = 0.000446, providing a **220,000× safety margin**.
+The topological capacity κ_T = 1/61 bounds the amplitude of deviations. The controlled magnitude of ‖δφ‖ places K₇ in the regime where Joyce's perturbative correction achieves a torsion-free G₂ structure. Joyce's theorem guarantees existence when ‖T‖ < ε₀ = 0.1; Monte Carlo validation (N=1000) confirms ‖T‖_max = 4.5 × 10⁻⁷, providing a **220,000× safety margin**.
 
 | Property | Value |
 |----------|-------|
@@ -426,9 +426,9 @@ A natural concern arises: why *this particular* algebraic combination of topolog
 |------------|-------|------------------------|----------|
 | sin²θ_W | 3/13 | 14 | N_gen/α_sum, b₂/(b₃+dim_G₂), dim(J₃O)/(dim_F₄+65) |
 | Q_Koide | 2/3 | 20 | dim_G₂/b₂, p₂/N_gen, dim_F₄/dim_E₆, rank_E₈/12 |
-| m_b/m_t | 1/42 | 21 | 1/χ(K₇), p₂/84, N_gen/126, 4/PSL(2,7) |
+| m_b/m_t | 1/42 | 21 | 1/(2b₂), p₂/84, N_gen/126, 4/PSL(2,7) |
 
-The bottom-to-top mass ratio 1/42 exemplifies this principle: it equals the inverse Euler characteristic of K₇, but also arises from 21 other combinations of topological invariants, all reducing to the same fraction.
+The bottom-to-top mass ratio 1/42 exemplifies this principle: it equals the inverse of 2b₂ (twice the gauge moduli count), but also arises from 21 other combinations of topological invariants, all reducing to the same fraction.
 
 **Classification by redundancy**: We classify observables by the number of independent expressions:
 
@@ -677,11 +677,13 @@ The neutrino mixing angles involve the auxiliary parameters:
 | n_s | ζ(11)/ζ(5) | 0.9649 | 0.9649 ± 0.0042 | **0.004%** |
 | h (Hubble) | (PSL₂₇-1)/dim(E₈) = 167/248 | 0.6734 | 0.674 ± 0.005 | **0.09%** |
 | Ω_b/Ω_m | Weyl/det(g)_den = 5/32 | 0.1562 | 0.157 ± 0.003 | **0.16%** |
-| σ₈ | (p₂+32)/χ = 34/42 | 0.8095 | 0.811 ± 0.006 | **0.18%** |
+| σ₈ | (p₂+32)/(2b₂) = 34/42 | 0.8095 | 0.811 ± 0.006 | **0.18%** |
 | Ω_DE | ln(2)×(b₂+b₃)/H* | 0.6861 | 0.6847 ± 0.0073 | **0.21%** |
 | Y_p | (1+dim_G₂)/κ_T⁻¹ = 15/61 | 0.2459 | 0.245 ± 0.003 | **0.37%** |
 
-**Most remarkable**: Ω_DM/Ω_b = (1 + 42)/8 = **43/8** is exact. The same χ(K₇) = 42 that gives m_b/m_t = 1/42 determines the dark-to-baryonic matter ratio.
+**Most remarkable**: Ω_DM/Ω_b = (1 + 2b₂)/rank(E₈) = (1 + 42)/8 = **43/8** is exact. The structural constant 2b₂ = 42 that gives m_b/m_t = 1/42 also determines the dark-to-baryonic matter ratio.
+
+**Note on notation**: The constant 42 = 2b₂ = p₂ × b₂ is a structural invariant, not to be confused with the Euler characteristic χ(K₇) = 0 (which vanishes for any compact odd-dimensional manifold).
 
 ### 9.6 CKM Matrix
 
@@ -698,10 +700,10 @@ The Cabibbo angle emerges from the ratio of E₇ fundamental representation to E
 | Observable | Formula | GIFT | Experimental | Deviation |
 |------------|---------|------|--------------|-----------|
 | m_H/m_W | (N_gen+dim_E₆)/dim(F₄) = 81/52 | 1.5577 | 1.558 ± 0.002 | **0.02%** |
-| m_W/m_Z | (χ-Weyl)/χ = **37/42** | 0.8810 | 0.8815 ± 0.0002 | **0.06%** |
+| m_W/m_Z | (2b₂-Weyl)/(2b₂) = **37/42** | 0.8810 | 0.8815 ± 0.0002 | **0.06%** |
 | m_H/m_t | fund(E₇)/b₃ = 56/77 | 0.7273 | 0.725 ± 0.003 | **0.31%** |
 
-**v3.3 correction**: m_W/m_Z = (42-5)/42 = **37/42** replaces previous formula with 8.7% error. The new formula achieves 0.06% precision.
+**v3.3 correction**: m_W/m_Z = (2b₂-Weyl)/(2b₂) = **37/42** replaces the previous 23/26 formula (0.35% deviation). The new formula achieves 0.06% precision, improving by a factor of 6.
 
 ---
 


### PR DESCRIPTION
- Rename χ(K₇)=42 to structural constant 2b₂ (true Euler char is 0)
- Fix m_W/m_Z percentage: 23/26 had 0.35% error, not 8.7%
- Harmonize torsion values: ‖T‖_max = 4.5×10⁻⁷ across all docs
- Add clarifying notes distinguishing 2b₂ from χ(K₇)