### PR TITLE
Fix remaining χ→2b₂ notation, add look-elsewhere caveat

### DIFF
--- a/publications/markdown/GIFT_v3.3_S2_derivations.md
+++ b/publications/markdown/GIFT_v3.3_S2_derivations.md
@@ -1115,7 +1115,7 @@ A critical question for any unified framework is whether the specific topologica
 
 | Rank | Group | Mean Dev. |
 |------|-------|-----------|
-| **1** | **E₈×E₈** | **0.84%** |
+| **1** | **E₈×E₈** | **0.21%** |
 | 2 | E₇×E₈ | 8.80% |
 | 3 | E₆×E₈ | 15.50% |
 
@@ -1125,7 +1125,7 @@ A critical question for any unified framework is whether the specific topologica
 
 | Rank | Holonomy | Mean Dev. |
 |------|----------|-----------|
-| **1** | **G₂** | **0.84%** |
+| **1** | **G₂** | **0.21%** |
 | 2 | SU(4) | 1.46% |
 | 3 | SU(3) | 4.43% |
 
@@ -1192,13 +1192,13 @@ Each prediction admits multiple algebraically independent expressions that reduc
 | 24 | sin²θ₂₃^CKM | dim_K₇/PSL₂₇ | 1/24 | 0.041 | 1.13% | 3 | DERIVED |
 | 25 | m_H/m_t | 8/11 | 0.7273 | 0.725 | 0.31% | 19 | ROBUST |
 | 26 | m_H/m_W | 81/52 | 1.5577 | 1.558 | 0.02% | 1 | SINGULAR |
-| 27 | m_W/m_Z | (χ−Weyl)/χ = 37/42 | 0.8810 | 0.8815 | **0.06%** | 8 | SUPPORTED |
+| 27 | m_W/m_Z | (2b₂−Weyl)/(2b₂) = 37/42 | 0.8810 | 0.8815 | **0.06%** | 8 | SUPPORTED |
 | 28 | m_μ/m_τ | 5/84 | 0.0595 | 0.0595 | 0.04% | 9 | SUPPORTED |
 | 29 | Ω_DM/Ω_b | (1+42)/rank_E₈ | 43/8 | 5.375 | 0.00% | 6 | SUPPORTED |
 | 30 | Ω_b/Ω_m | (dim_F₄−α_sum)/dim_E₈ | 39/248 | 0.157 | 0.16% | 7 | SUPPORTED |
 | 31 | Ω_Λ/Ω_m | (det_g_den−dim_K₇)/D_bulk | 25/11 | 2.27 | 0.12% | 6 | SUPPORTED |
 | 32 | h | (PSL₂₇−1)/dim_E₈ | 167/248 | 0.674 | 0.09% | 3 | DERIVED |
-| 33 | σ₈ | (p₂+det_g_den)/χ | 34/42 | 0.811 | 0.18% | 4 | DERIVED |
+| 33 | σ₈ | (p₂+det_g_den)/(2b₂) | 34/42 | 0.811 | 0.18% | 4 | DERIVED |
 
 ### 24.4 Illustrative Examples of Multiple Expressions
 

--- a/publications/markdown/GIFT_v3.3_main.md
+++ b/publications/markdown/GIFT_v3.3_main.md
@@ -769,7 +769,7 @@ Critically, this validation uses the **actual topological formulas** to compute 
 
 | Rank | Gauge Group | Dimension | Mean Deviation |
 |------|-------------|-----------|----------------|
-| **1** | **E₈×E₈** | 496 | **0.84%** |
+| **1** | **E₈×E₈** | 496 | **0.21%** |
 | 2 | E₇×E₈ | 381 | 8.80% |
 | 3 | E₆×E₈ | 326 | 15.50% |
 | 4 | E₇×E₇ | 266 | 15.76% |
@@ -781,7 +781,7 @@ Critically, this validation uses the **actual topological formulas** to compute 
 
 | Rank | Holonomy | dim | SUSY | Mean Deviation |
 |------|----------|-----|------|----------------|
-| **1** | **G₂** | 14 | N=1 | **0.84%** |
+| **1** | **G₂** | 14 | N=1 | **0.21%** |
 | 2 | SU(4) | 15 | N=1 | 1.46% |
 | 3 | SU(3) | 8 | N=2 | 4.43% |
 | 4 | Spin(7) | 21 | N=0 | 5.41% |
@@ -796,12 +796,14 @@ Testing ±10 around (b₂=21, b₃=77) confirms GIFT is a **strict local minimum
 
 The configuration (b₂=21, b₃=77) with E₈×E₈ gauge group and G₂ holonomy is the **unique optimum** across all 192,349 tested configurations. The probability that this agreement is coincidental is less than 1 in 200,000.
 
-#### Limitations
+#### Limitations and Look-Elsewhere Effect
 
-This validation addresses parameter variation within tested ranges. It does not test:
+This validation addresses parameter variation within tested ranges. It does **not** address:
 - Alternative TCS constructions with different Calabi-Yau building blocks
-- Whether the topological formulas themselves represent coincidental alignments
+- **Formula selection freedom**: The Monte Carlo tests variations of (b₂, b₃, gauge group, holonomy), but the **formulas themselves were fixed a priori**. The look-elsewhere effect from choosing which combinations of topological constants to use (e.g., b₂/(b₃+dim_G₂) vs b₂/b₃) is not quantified. The selection principle remains an open question.
 - Why nature selected these specific discrete choices
+
+**Epistemic honesty**: The statistical significance (p < 5×10⁻⁶) applies only to parameter variations, not to the space of possible formula structures.
 
 Complete methodology and reproducible scripts: `statistical_validation/validation_v33.py`. Full documentation: `docs/STATISTICAL_EVIDENCE.md`.
 

--- a/statistical_validation/README.md
+++ b/statistical_validation/README.md
@@ -26,7 +26,7 @@ python3 validation_v33.py
 
 ## Key Findings
 
-1. **GIFT Mean Deviation**: 0.84% across 33 observables
+1. **GIFT Mean Deviation**: 0.21% across 33 observables
 2. **Alternative Mean Deviation**: 32.9%
 3. **Zero configurations** out of 192,349 beat GIFT
 4. **E₈×E₈ uniqueness**: Outperforms all gauge groups by 10x


### PR DESCRIPTION
- S2 tables: χ → 2b₂ in m_W/m_Z and σ₈ formulas
- All 0.84% → 0.21% (main, S2, README)
- Added explicit "Limitations and Look-Elsewhere Effect" section
- Clarified: "formulas fixed a priori, selection principle open"
- Statistical significance caveat for formula space