### PR TITLE
docs: Synchronize all documentation to v3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ All notable changes to the GIFT framework are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0] - 2026-01-12
+
+### Extended Observable Catalog & Enhanced Monte Carlo Validation
+
+This release extends the observable catalog from 18 to 33 predictions and significantly expands Monte Carlo validation.
+
+#### Added
+
+**Extended Observable Catalog (33 predictions)**
+- 18 core relations (PROVEN in Lean 4)
+- 15 extended relations (TOPOLOGICAL/HEURISTIC status)
+- Mean deviation improved: 0.24% → **0.21%** (PDG 2024)
+
+**Enhanced Monte Carlo Validation**
+- Total configurations tested: 54,327 → **192,349**
+- p-value: < 10⁻⁵ → **< 5×10⁻⁶**
+- Significance: >4σ → **>4.5σ**
+
+**New v3.3 Corrections**
+- m_W/m_Z formula: 23/26 → **37/42** = (2b₂−Weyl)/(2b₂) — deviation 0.35% → 0.06%
+- Both Betti numbers now **DERIVED** from TCS building blocks, not input
+
+**File Renames (v3.2 → v3.3)**
+- `GIFT_v3.2_main.md` → `GIFT_v3.3_main.md`
+- `GIFT_v3.2_S1_foundations.md` → `GIFT_v3.3_S1_foundations.md`
+- `GIFT_v3.2_S2_derivations.md` → `GIFT_v3.3_S2_derivations.md`
+- `GIFT_v3.2_S3_dynamics.md` → `GIFT_v3.3_S3_dynamics.md`
+
+**New Documentation**
+- `docs/OBSERVABLE_CATALOG.md`: Complete 33-observable catalog
+- `docs/OBSERVABLE_REFERENCE.md`: Detailed reference for all predictions
+- `docs/STATISTICAL_EVIDENCE.md`: v3.3 statistical validation summary
+- `statistical_validation/validation_v33.py`: Enhanced validation script
+- `statistical_validation/GIFT_Statistical_Validation_Report_v33.md`: Full report
+
+#### Changed
+
+**Notation Clarification**
+- χ(K₇) = 0 (Euler characteristic for odd-dimensional manifolds)
+- The constant 42 = 2b₂ is a distinct structural invariant, NOT χ(K₇)
+
+**Documentation Updates**
+- All READMEs updated to v3.3
+- CITATION.md updated with v3.3 references
+- STRUCTURE.md updated with new file names
+
+---
+
 ## [3.2.0] - 2026-01-05
 
 ### PDG 2024 Update & Comprehensive Monte Carlo Validation

--- a/CITATION.md
+++ b/CITATION.md
@@ -1,6 +1,6 @@
 # Citation Guide
 
-Citation formats for the GIFT Framework v3.2.
+Citation formats for the GIFT Framework v3.3.
 
 ## Software Citation (Recommended)
 
@@ -8,26 +8,26 @@ Citation formats for the GIFT Framework v3.2.
 
 ```bibtex
 @software{gift_framework_v32,
-  title   = {GIFT Framework v3.2: Geometric Information Field Theory},
+  title   = {GIFT Framework v3.3: Geometric Information Field Theory},
   author  = {de La Fournière, Brieuc},
-  year    = {2025},
+  year    = {2026},
   url     = {https://github.com/gift-framework/GIFT},
-  version = {3.2.0},
+  version = {3.3.0},
   license = {MIT},
-  note    = {18 dimensionless predictions, 0.24\% mean deviation (PDG 2024), 185 certified relations}
+  note    = {33 dimensionless predictions, 0.21\% mean deviation (PDG 2024), 185 certified relations}
 }
 ```
 
 ### APA Style
 
 ```
-de La Fournière, B. (2025). GIFT Framework v3.2: Geometric Information Field Theory (Version 3.2.0) [Software]. GitHub. https://github.com/gift-framework/GIFT
+de La Fournière, B. (2025). GIFT Framework v3.3: Geometric Information Field Theory (Version 3.3.0) [Software]. GitHub. https://github.com/gift-framework/GIFT
 ```
 
 ### Chicago Style
 
 ```
-de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theory." Version 3.2.0. GitHub, 2025. https://github.com/gift-framework/GIFT.
+de La Fournière, Brieuc. "GIFT Framework v3.3: Geometric Information Field Theory." Version 3.3.0. GitHub, 2025. https://github.com/gift-framework/GIFT.
 ```
 
 ---
@@ -38,10 +38,10 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 
 ```bibtex
 @article{gift_theory_v32,
-  title  = {Geometric Information Field Theory v3.2: Topological Determination of Standard Model Parameters},
+  title  = {Geometric Information Field Theory v3.3: Topological Determination of Standard Model Parameters},
   author = {de La Fournière, Brieuc},
-  year   = {2025},
-  note   = {Mean deviation 0.24\% (PDG 2024) across 18 dimensionless predictions, zero continuous adjustable parameters, 185 proven exact relations},
+  year   = {2026},
+  note   = {Mean deviation 0.24\% (PDG 2024) across 33 dimensionless predictions, zero continuous adjustable parameters, 185 proven exact relations},
   url    = {https://github.com/gift-framework/GIFT}
 }
 ```
@@ -56,9 +56,9 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 @misc{gift_main_v32,
   title        = {Geometric Information Field Theory: Topological Determination of Standard Model Parameters},
   author       = {de La Fournière, Brieuc},
-  year         = {2025},
-  howpublished = {GIFT Framework v3.2},
-  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.2_main.md}
+  year         = {2026},
+  howpublished = {GIFT Framework v3.3},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.3_main.md}
 }
 ```
 
@@ -68,9 +68,9 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 @misc{gift_s1_foundations,
   title        = {GIFT S1: Mathematical Foundations - E₈, G₂, K₇},
   author       = {de La Fournière, Brieuc},
-  year         = {2025},
-  howpublished = {GIFT Framework v3.2, Supplement S1},
-  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.2_S1_foundations.md}
+  year         = {2026},
+  howpublished = {GIFT Framework v3.3, Supplement S1},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.3_S1_foundations.md}
 }
 ```
 
@@ -80,9 +80,9 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 @misc{gift_s2_derivations,
   title        = {GIFT S2: Complete Derivations - 18 Dimensionless Observables},
   author       = {de La Fournière, Brieuc},
-  year         = {2025},
-  howpublished = {GIFT Framework v3.2, Supplement S2},
-  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.2_S2_derivations.md}
+  year         = {2026},
+  howpublished = {GIFT Framework v3.3, Supplement S2},
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.3_S2_derivations.md}
 }
 ```
 
@@ -96,10 +96,10 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 @misc{gift_cp_violation,
   title        = {Exact Topological Formula for CP Violation Phase: δ_CP = 197°},
   author       = {de La Fournière, Brieuc},
-  year         = {2025},
-  howpublished = {GIFT Framework v3.2},
+  year         = {2026},
+  howpublished = {GIFT Framework v3.3},
   note         = {Formula: δ_CP = dim(K₇)×dim(G₂) + H* = 7×14 + 99 = 197°},
-  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.2_S2_derivations.md}
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.3_S2_derivations.md}
 }
 ```
 
@@ -109,10 +109,10 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 @misc{gift_weinberg_angle,
   title        = {Topological Derivation of Weinberg Angle: sin²θ_W = 3/13},
   author       = {de La Fournière, Brieuc},
-  year         = {2025},
-  howpublished = {GIFT Framework v3.2},
+  year         = {2026},
+  howpublished = {GIFT Framework v3.3},
   note         = {Formula: sin²θ_W = b₂/(b₃ + dim(G₂)) = 21/91 = 3/13},
-  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.2_S2_derivations.md}
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.3_S2_derivations.md}
 }
 ```
 
@@ -122,10 +122,10 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 @misc{gift_generation_number,
   title        = {Topological Proof of Three Fermion Generations},
   author       = {de La Fournière, Brieuc},
-  year         = {2025},
-  howpublished = {GIFT Framework v3.2},
+  year         = {2026},
+  howpublished = {GIFT Framework v3.3},
   note         = {N_gen = 3 from Atiyah-Singer index theorem on K₇},
-  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.2_S1_foundations.md}
+  url          = {https://github.com/gift-framework/GIFT/blob/main/publications/markdown/GIFT_v3.3_S1_foundations.md}
 }
 ```
 
@@ -137,9 +137,9 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 @software{gift_core_v320,
   title   = {GIFT Core: Formal Verification in Lean 4 + Coq},
   author  = {de La Fournière, Brieuc},
-  year    = {2025},
+  year    = {2026},
   url     = {https://github.com/gift-framework/core},
-  version = {3.2.0},
+  version = {3.3.0},
   note    = {185 relations verified, 40 axioms, K₇ metric pipeline, Joyce existence theorem}
 }
 ```
@@ -159,7 +159,7 @@ de La Fournière, Brieuc. "GIFT Framework v3.2: Geometric Information Field Theo
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| 3.2.0 | 2026-01-05 | PDG 2024 values, 54,327-config Monte Carlo validation |
+| 3.3.0 | 2026-01-05 | PDG 2024 values, 54,327-config Monte Carlo validation |
 | 3.1.0 | 2025-12-17 | Analytical G₂ metric, 185 certified relations |
 | 3.0.0 | 2025-12-09 | Major release: 165+ certified relations, Fibonacci/Monster/McKay |
 | 2.3.x | 2025-12 | Dual Lean 4 + Coq verification |
@@ -175,14 +175,14 @@ When using GIFT predictions:
 
 1. **Cite framework** - Use software citation above
 2. **Cite specific results** - Use appropriate document citation
-3. **Specify version** - Always include version number (v3.2)
+3. **Specify version** - Always include version number (v3.3)
 4. **Link repository** - Include GitHub URL for reproducibility
 
 ### Example
 
 > "We compare our measurements with predictions from the Geometric Information Field Theory (GIFT) framework [1], which derives Standard Model parameters from E₈×E₈ topology. The GIFT prediction for the CP violation phase is δ_CP = 197° [2]."
 >
-> [1] de La Fournière, B. "GIFT Framework v3.2," 2025, https://github.com/gift-framework/GIFT
+> [1] de La Fournière, B. "GIFT Framework v3.3," 2025, https://github.com/gift-framework/GIFT
 >
 > [2] de La Fournière, B. "GIFT S2: Complete Derivations," 2025.
 
@@ -194,4 +194,4 @@ MIT License - See [LICENSE](LICENSE)
 
 ---
 
-**Version**: 3.2.0 (2026-01-05)
+**Version**: 3.3.0 (2026-01-05)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,10 @@ This repository contains the **theoretical documentation** for GIFT (Geometric I
 GIFT/
 ├── publications/
 │   ├── markdown/           # Core documents
-│   │   ├── GIFT_v3.2_main.md        # Main paper (accessible, quasi-autonomous)
-│   │   ├── GIFT_v3.2_S1_foundations.md  # E₈, G₂, K₇ foundations
-│   │   ├── GIFT_v3.2_S2_derivations.md  # All dimensionless derivations
-│   │   └── GIFT_v3.2_S3_dynamics.md     # RG flow, torsional dynamics
+│   │   ├── GIFT_v3.3_main.md        # Main paper (accessible, quasi-autonomous)
+│   │   ├── GIFT_v3.3_S1_foundations.md  # E₈, G₂, K₇ foundations
+│   │   ├── GIFT_v3.3_S2_derivations.md  # All dimensionless derivations
+│   │   └── GIFT_v3.3_S3_dynamics.md     # RG flow, torsional dynamics
 │   ├── references/         # Extended topics (number theory, speculative physics)
 │   ├── tex/               # LaTeX sources
 │   └── pdf/               # Generated PDFs

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to GIFT.
 
 ## Documentation Contributions
 
-This repository contains the theoretical documentation for GIFT v3.2. Contributions welcome:
+This repository contains the theoretical documentation for GIFT v3.3. Contributions welcome:
 
 - **Clarifications**: Improve explanations of concepts
 - **Corrections**: Fix errors in derivations or references

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Geometric Information Field Theory v3.2
+# Geometric Information Field Theory v3.3
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-3.2.0-green.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/Version-3.3.0-green.svg)](CHANGELOG.md)
 [![Lean 4 + Coq](https://img.shields.io/badge/Formally_Verified-Lean_4_+_Coq-blue)](https://github.com/gift-framework/core)
 
 **Standard Model parameters from pure geometry** — E₈×E₈ on G₂-holonomy manifold K₇, zero adjustable parameters.
@@ -12,10 +12,10 @@
 
 | | |
 |---|---|
-| **Precision** | 0.24% mean deviation across 18 dimensionless predictions (PDG 2024) |
-| **Uniqueness** | #1 out of 54,327 configurations tested (>4σ significance) |
+| **Precision** | 0.21% mean deviation across 33 dimensionless predictions (PDG 2024) |
+| **Uniqueness** | #1 out of 192,349 configurations tested (>4.5σ significance) |
 | **Parameters** | Zero adjustable (all structurally determined) |
-| **Verified** | 185 relations proven in Lean 4 + Coq (40 axioms, core v3.2.0) |
+| **Verified** | 185 relations proven in Lean 4 + Coq (40 axioms, core v3.3.0) |
 | **Exact results** | sin²θ_W = 3/13 · τ = 3472/891 · det(g) = 65/32 · Monster = 47×59×71 |
 
 **Dimensional reduction:** E₈×E₈ (496D) → AdS₄ × K₇ (11D) → Standard Model (4D)
@@ -26,7 +26,7 @@
 
 | Paper | Proofs | Video |
 |:-----:|:------:|:-----:|
-| [Main Paper](publications/markdown/GIFT_v3.2_main.md) | [Lean 4 + Coq](https://github.com/gift-framework/core) | [YouTube (8 min)](https://www.youtube.com/watch?v=6DVck30Q6XM) |
+| [Main Paper](publications/markdown/GIFT_v3.3_main.md) | [Lean 4 + Coq](https://github.com/gift-framework/core) | [YouTube (8 min)](https://www.youtube.com/watch?v=6DVck30Q6XM) |
 
 ---
 
@@ -36,10 +36,10 @@
 
 | Document | Description |
 |----------|-------------|
-| [Main Paper](publications/markdown/GIFT_v3.2_main.md) | Complete theoretical framework |
-| [S1: Foundations](publications/markdown/GIFT_v3.2_S1_foundations.md) | E₈, G₂, K₇ mathematical construction |
-| [S2: Derivations](publications/markdown/GIFT_v3.2_S2_derivations.md) | All 18 dimensionless derivations (0.24% mean, PDG 2024) |
-| [S3: Dynamics](publications/markdown/GIFT_v3.2_S3_dynamics.md) | RG flow, torsional dynamics |
+| [Main Paper](publications/markdown/GIFT_v3.3_main.md) | Complete theoretical framework |
+| [S1: Foundations](publications/markdown/GIFT_v3.3_S1_foundations.md) | E₈, G₂, K₇ mathematical construction |
+| [S2: Derivations](publications/markdown/GIFT_v3.3_S2_derivations.md) | All 33 dimensionless derivations (0.21% mean, PDG 2024) |
+| [S3: Dynamics](publications/markdown/GIFT_v3.3_S3_dynamics.md) | RG flow, torsional dynamics |
 
 ### For Specific Audiences
 
@@ -114,15 +114,15 @@ Joyce's existence theorem is **trivially satisfied** — no numerical fitting re
 
 Comprehensive validation confirms that (b₂=21, b₃=77) is not merely a good choice but the **unique optimum** among G₂ manifold configurations.
 
-### Exhaustive Search Results (v3.2)
+### Exhaustive Search Results (v3.3)
 
 | Metric | Value |
 |--------|-------|
-| Configurations tested | 54,327 |
+| Configurations tested | 192,349 |
 | **GIFT rank** | **#1** |
-| GIFT mean deviation | 0.24% (PDG 2024) |
+| GIFT mean deviation | 0.21% (PDG 2024) |
 | Better alternatives found | 0 |
-| p-value | < 10⁻⁵ |
+| p-value | < 5×10⁻⁶ |
 
 ### Top 5 Configurations
 
@@ -134,11 +134,11 @@ Comprehensive validation confirms that (b₂=21, b₃=77) is not merely a good c
 | 4 | 21 | 79 | 0.79% |
 | 5 | 21 | 75 | 0.81% |
 
-### Statistical Significance (v3.2 Monte Carlo)
+### Statistical Significance (v3.3 Monte Carlo)
 
-- **LEE-corrected significance**: >4σ
-- **p-value**: < 10⁻⁵
-- **Total configurations tested**: 54,327 (Betti, holonomy, structural variations)
+- **LEE-corrected significance**: >4.5σ
+- **p-value**: < 5×10⁻⁶
+- **Total configurations tested**: 192,349 (Betti, holonomy, structural variations)
 - **Better alternatives found**: 0
 
 GIFT occupies a **sharp minimum**: no tested alternative matches its precision.
@@ -156,7 +156,7 @@ Details: [Uniqueness Test Report](statistical_validation/UNIQUENESS_TEST_REPORT.
 | m_s/m_d = 20 | Lattice QCD | 2030 | Converges outside [19, 21] |
 | N_gen = 3 | LHC | Ongoing | Fourth generation discovery |
 
-Details: [S2 Section 10](publications/markdown/GIFT_v3.2_S2_derivations.md)
+Details: [S2 Section 10](publications/markdown/GIFT_v3.3_S2_derivations.md)
 
 ---
 
@@ -221,12 +221,12 @@ Their appearance suggests structural rather than coincidental relationships.
 ## Citation
 
 ```bibtex
-@software{gift_framework_v32,
-  title   = {GIFT Framework v3.2: Geometric Information Field Theory},
+@software{gift_framework_v33,
+  title   = {GIFT Framework v3.3: Geometric Information Field Theory},
   author  = {de La Fournière, Brieuc},
-  year    = {2025},
+  year    = {2026},
   url     = {https://github.com/gift-framework/GIFT},
-  version = {3.2.0}
+  version = {3.3.0}
 }
 ```
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -1,6 +1,6 @@
 # Repository Structure
 
-This repository contains the theoretical documentation for GIFT v3.2.
+This repository contains the theoretical documentation for GIFT v3.3.
 
 ## Directory Layout
 
@@ -8,11 +8,11 @@ This repository contains the theoretical documentation for GIFT v3.2.
 GIFT/
 ├── publications/                     # Theoretical documents
 │   ├── README.md                    # Overview and reading guide
-│   ├── markdown/                    # Core documents (v3.2)
-│   │   ├── GIFT_v3.2_main.md         # Main paper
-│   │   ├── GIFT_v3.2_S1_foundations.md   # E₈, G₂, K₇ foundations
-│   │   ├── GIFT_v3.2_S2_derivations.md   # 18 dimensionless derivations
-│   │   └── GIFT_v3.2_S3_dynamics.md      # Torsional flow, scale bridge
+│   ├── markdown/                    # Core documents (v3.3)
+│   │   ├── GIFT_v3.3_main.md         # Main paper
+│   │   ├── GIFT_v3.3_S1_foundations.md   # E₈, G₂, K₇ foundations
+│   │   ├── GIFT_v3.3_S2_derivations.md   # 33 dimensionless derivations
+│   │   └── GIFT_v3.3_S3_dynamics.md      # Torsional flow, scale bridge
 │   ├── references/                  # Exploratory & reference docs
 │   │   ├── 39_observables.csv      # Machine-readable observables
 │   │   ├── NUMBER_THEORETIC_STRUCTURES.md  # Fibonacci, Prime Atlas, Monster
@@ -32,8 +32,8 @@ GIFT/
 │   └── legacy/                      # Archived v2.3/v3.0 supplements
 │
 ├── statistical_validation/          # Monte Carlo validation
-│   ├── validation_v32.py           # v3.2 comprehensive validation
-│   └── validation_v32_results.json # v3.2 results
+│   ├── validation_v32.py           # v3.3 comprehensive validation
+│   └── validation_v32_results.json # v3.3 results
 │
 ├── README.md                        # Main repository overview
 ├── CHANGELOG.md                     # Version history
@@ -47,22 +47,22 @@ GIFT/
 | Looking for... | Go to |
 |----------------|-------|
 | Framework overview | `README.md` |
-| Complete theory | `publications/markdown/GIFT_v3.2_main.md` |
-| All derivations | `publications/markdown/GIFT_v3.2_S2_derivations.md` |
+| Complete theory | `publications/markdown/GIFT_v3.3_main.md` |
+| All derivations | `publications/markdown/GIFT_v3.3_S2_derivations.md` |
 | Observables data | `publications/references/39_observables.csv` |
 | Monte Carlo validation | `statistical_validation/validation_v32.py` |
 | Formal verification | [gift-framework/core](https://github.com/gift-framework/core) |
 | Technical definitions | `docs/GLOSSARY.md` |
 | Legacy supplements | `docs/legacy/` |
 
-## Core Documents (v3.2)
+## Core Documents (v3.3)
 
 | Document | Content |
 |----------|---------|
-| GIFT_v3.2_main.md | Complete theoretical framework |
-| GIFT_v3.2_S1_foundations.md | E₈, G₂, K₇ mathematical construction |
-| GIFT_v3.2_S2_derivations.md | 18 dimensionless derivations with proofs |
-| GIFT_v3.2_S3_dynamics.md | Torsional dynamics, scale bridge |
+| GIFT_v3.3_main.md | Complete theoretical framework |
+| GIFT_v3.3_S1_foundations.md | E₈, G₂, K₇ mathematical construction |
+| GIFT_v3.3_S2_derivations.md | 33 dimensionless derivations with proofs |
+| GIFT_v3.3_S3_dynamics.md | Torsional dynamics, scale bridge |
 
 ## Exploratory References
 
@@ -79,8 +79,8 @@ GIFT/
 
 ## Version
 
-**Current**: v3.2.0 (2026-01-05)
-**Relations**: 185 certified (core v3.2.0)
-**Predictions**: 18 dimensionless (**0.24% mean deviation, PDG 2024**)
-**Monte Carlo**: 54,327 configurations tested, 0 better than GIFT
+**Current**: v3.3.0 (2026-01-12)
+**Relations**: 185 certified (core v3.3.0)
+**Predictions**: 33 dimensionless (**0.21% mean deviation, PDG 2024**)
+**Monte Carlo**: 192,349 configurations tested, 0 better than GIFT
 **Key Result**: Analytical G₂ metric with T = 0 exactly

--- a/docs/EXPERIMENTAL_VALIDATION.md
+++ b/docs/EXPERIMENTAL_VALIDATION.md
@@ -4,13 +4,13 @@ Current experimental status of GIFT predictions, precision comparisons, and time
 
 ## Overview
 
-The GIFT framework v3.2 makes 18 dimensionless predictions with mean experimental deviation of 0.24% (PDG 2024). This document tracks:
+The GIFT framework v3.3 makes 33 dimensionless predictions with mean experimental deviation of 0.21% (PDG 2024). This document tracks:
 - Current experimental status for each prediction
 - Precision evolution over time
 - Planned experiments and timelines
 - Criteria for validation or falsification
 
-**Last updated**: 2026-01-05 (v3.2.0)
+**Last updated**: 2026-01-12 (v3.3.0)
 
 ## Current Experimental Status Summary
 
@@ -36,7 +36,7 @@ The GIFT framework v3.2 makes 18 dimensionless predictions with mean experimenta
 - Most CKM matrix elements: mean 0.11%
 - Most quark mass ratios
 
-**Overall**: 18 dimensionless predictions, mean deviation 0.24% (v3.2 core set, PDG 2024)
+**Overall**: 33 dimensionless predictions (18 core + 15 extended), mean deviation 0.21% (v3.3, PDG 2024)
 
 ### By Physics Sector
 
@@ -346,8 +346,8 @@ No sector shows systematic problems. All perform well.
 - Perfect fit by construction (parameters chosen to match)
 - No predictive power for these 19 numbers
 
-**GIFT v3.2**: Zero continuous adjustable parameters, 18 dimensionless predictions
-- Mean deviation 0.24% (PDG 2024) without adjusting
+**GIFT v3.3**: Zero continuous adjustable parameters, 33 dimensionless predictions
+- Mean deviation 0.21% (PDG 2024) without adjusting
 - Genuine predictive power
 - Complete elimination of free parameters
 - All quantities structurally determined

--- a/docs/EXTENDED_OBSERVABLES.md
+++ b/docs/EXTENDED_OBSERVABLES.md
@@ -40,7 +40,7 @@ The "formula selection problem" dissolves: each observable corresponds to a **un
 | b₂ | 21 | Second Betti number | 0 |
 | dim(J₃(O)) | 27 | Exceptional Jordan algebra | 6 |
 | det(g)_den | 32 | Metric determinant denominator | 4 |
-| χ(K₇) | 42 | Euler characteristic | 0 |
+| 2b₂ | 42 | Structural invariant (note: χ(K₇)=0) | 0 |
 | dim(F₄) | 52 | F₄ dimension | 3 |
 | fund(E₇) | 56 | E₇ fundamental representation | 0 |
 | κ_T⁻¹ | 61 | Inverse torsion capacity | 5 |
@@ -99,9 +99,9 @@ The "formula selection problem" dissolves: each observable corresponds to a **un
 |-------|-----------------|------------------|
 | m_s/m_d = 20 | (α_sum + dim_J₃O)/p₂ | Anomaly + Jordan / duality |
 | m_c/m_s ≈ 82/7 | (dim_E₈ - p₂)/b₂ | Gauge dimension / moduli |
-| m_b/m_t = 1/42 | 1/χ(K₇) | **Inverse Euler characteristic** |
+| m_b/m_t = 1/42 | 1/(2b₂) | **Inverse structural invariant** |
 
-**Key insight**: m_b/m_t = 1/42 = 1/χ(K₇). The bottom/top mass hierarchy is literally the inverse Euler characteristic of the compact manifold.
+**Key insight**: m_b/m_t = 1/42 = 1/(2b₂). The bottom/top mass hierarchy is the inverse of the structural constant 2b₂. (Note: χ(K₇) = 0 for odd-dimensional manifolds; 42 = 2b₂ is a distinct invariant.)
 
 ### 2.4 Cosmological Parameters
 
@@ -155,7 +155,7 @@ Strong correspondences have multiple independent derivations:
 
 | # | Expression | Computation |
 |---|------------|-------------|
-| 1 | b₀/χ(K₇) | 1/42 |
+| 1 | b₀/(2b₂) | 1/42 |
 | 2 | (b₀+N_gen)/PSL₂₇ | 4/168 = 1/42 |
 | 3 | p₂/(dim_K₇+b₃) | 2/84 = 1/42 |
 | 4 | N_gen/(dim_J₃O+H*) | 3/126 = 1/42 |
@@ -204,7 +204,7 @@ Master identities connecting GIFT constants:
 | Weyl = 5 | 4 | Quadruple-determined |
 | PSL(2,7) = 168 | 4 | Quadruple-determined |
 | N_gen = 3 | 24+ | Highly over-determined |
-| 42 = χ(K₇) | 21 | Highly over-determined |
+| 42 = 2b₂ | 21 | Highly over-determined |
 
 Nature selects for **over-determined** quantities.
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -32,14 +32,14 @@ GIFT is a speculative theoretical framework presenting testable predictions. The
 
 The framework is evaluated based on:
 - Mathematical rigor of derivations
-- Precision of experimental agreement (currently 0.24% mean deviation across 18 dimensionless predictions, PDG 2024)
+- Precision of experimental agreement (currently 0.21% mean deviation across 33 dimensionless predictions, PDG 2024)
 - Falsifiability (clear criteria in Supplement S5)
 - Reproducibility (computational notebook available)
 
 ### How many free parameters?
 
 **Standard Model**: 19 free parameters
-**GIFT v3.2**: Zero continuous adjustable parameters
+**GIFT v3.3**: Zero continuous adjustable parameters
 
 All quantities derive from fixed topological structure (E₈×E₈ gauge group, K₇ manifold with G₂ holonomy). The framework achieves "structural determination" where discrete mathematical choices uniquely determine all predictions.
 
@@ -115,7 +115,7 @@ See Supplement S1 for complete mathematical details.
 
 ### What observables does GIFT predict?
 
-**18 dimensionless predictions** (v3.2 core set):
+**33 dimensionless predictions** (v3.3: 18 core + 15 extended):
 
 - 3 gauge couplings (α, sin²θ_W, α_s)
 - 1 generation number (N_gen = 3)
@@ -127,7 +127,7 @@ See Supplement S1 for complete mathematical details.
 - 2 electroweak parameters (λ_H, hierarchy)
 - 2 topological constants (κ_T, det(g))
 
-Mean deviation from experiment: **0.24%** (PDG 2024)
+Mean deviation from experiment: **0.21%** (PDG 2024)
 
 *Note: Extended dimensional predictions (masses, electroweak scale) are documented in legacy files (v2.3) with 0.197% mean deviation across 39 observables.*
 
@@ -161,7 +161,7 @@ The dimensional predictions (status: THEORETICAL/DERIVED) are less rigorous than
 - Gauge couplings: mean 0.03%
 - CKM matrix: mean 0.11%
 
-**Overall**: Mean 0.24% across 18 dimensionless predictions (v3.2, PDG 2024)
+**Overall**: Mean 0.21% across 33 dimensionless predictions (v3.3, PDG 2024)
 
 See Supplement S5 for detailed statistical analysis.
 
@@ -351,15 +351,15 @@ Depends on background:
 
 ### Is there a paper I can cite?
 
-Current version (v3.2.0) is available on GitHub. Citation format in `CITATION.md`:
+Current version (v3.3.0) is available on GitHub. Citation format in `CITATION.md`:
 
 ```bibtex
-@software{gift_framework_v32,
-  title={GIFT Framework v3.2: Geometric Information Field Theory},
+@software{gift_framework_v33,
+  title={GIFT Framework v3.3: Geometric Information Field Theory},
   author={de La Fournière, Brieuc},
-  year={2025},
+  year={2026},
   url={https://github.com/gift-framework/GIFT},
-  version={3.2.0}
+  version={3.3.0}
 }
 ```
 

--- a/docs/GIFT_Extended_Observables_v3_Final.md
+++ b/docs/GIFT_Extended_Observables_v3_Final.md
@@ -49,7 +49,7 @@
 | b₂ | 21 | 2nd Betti | **0** | 3×7 |
 | dim(J₃(𝕆)) | 27 | Jordan alg | 6 | — |
 | det(g)_den | 32 | Metric den | 4 | 2⁵ |
-| χ(K₇) | 42 | Euler char | **0** | 6×7 |
+| 2b₂ | 42 | Structural inv | **0** | 6×7 |
 | dim(F₄) | 52 | F₄ dim | 3 | — |
 | fund(E₇) | 56 | E₇ fund rep | **0** | 8×7 |
 | κ_T | 61 | Torsion inv | 5 | prime |
@@ -152,7 +152,7 @@ This is **not numerology** — it's the octonionic Fano structure manifesting in
 | m_u/m_d | 0.47±0.07 | (b₀+dim_E₆)/PSL27 = **79/168** | 0.470 | 0.05% | 4 |
 | m_d/m_s | 0.050±0.005 | (D_bulk+dim_G₂)/dim_E₈² | 0.0504 | 0.81% | 3 |
 
-**The 42 connection**: m_b/m_t = 1/χ(K₇) = 1/42
+**The 42 connection**: m_b/m_t = 1/(2b₂) = 1/42
 
 ### 3.4 Lepton Mass Ratios
 
@@ -209,7 +209,7 @@ This is **not numerology** — it's the octonionic Fano structure manifesting in
 **Most remarkable result**:
 $$\frac{\Omega_{DM}}{\Omega_b} = \frac{b_0 + \chi(K_7)}{\text{rank}(E_8)} = \frac{1 + 42}{8} = \frac{43}{8} = 5.375$$
 
-The ratio of dark matter to baryonic matter **explicitly contains χ(K₇) = 42**.
+The ratio of dark matter to baryonic matter **explicitly contains 2b₂ = 42**.
 
 ### 4.3 Physical Interpretation
 

--- a/docs/GIFT_Selection_Rules_Report.md
+++ b/docs/GIFT_Selection_Rules_Report.md
@@ -24,7 +24,7 @@ The Fano plane PG(2,2) is the smallest projective plane:
 | dim(K₇) | 7 | 1×7 | Internal dimension |
 | dim(G₂) | 14 | 2×7 | Holonomy group |
 | b₂ | 21 | 3×7 | Gauge moduli |
-| χ(K₇) | 42 | 6×7 | Euler characteristic |
+| 2b₂ | 42 | 6×7 | Structural invariant |
 | fund(E₇) | 56 | 8×7 | E₇ fundamental rep |
 | b₃ | 77 | 11×7 | Matter modes |
 | PSL(2,7) | 168 | 24×7 | Fano symmetry |
@@ -54,7 +54,7 @@ The first formula gives 0.231 (correct), the second gives 0.273 (wrong).
 
 **Old formula**: (b₂+p₂)/(b₂+N_gen) = 23/24 = 0.958 ❌
 
-**New formula**: (χ-Weyl)/χ = (42-5)/42 = 37/42 = 0.881 ✓
+**New formula**: (2b₂-Weyl)/(2b₂) = (42-5)/42 = 37/42 = 0.881 ✓
 
 | Metric | Value |
 |--------|-------|
@@ -62,7 +62,9 @@ The first formula gives 0.231 (correct), the second gives 0.273 (wrong).
 | Experimental | 0.8815 |
 | Deviation | **0.06%** |
 
-**Physical interpretation**: (Euler - pentagon) / Euler
+**Physical interpretation**: (2b₂ - Weyl) / 2b₂
+
+**Note**: The constant 42 = 2b₂ is a structural invariant, not the Euler characteristic. χ(K₇) = 0 for odd-dimensional manifolds.
 
 ### 2.2 θ₂₃ (previously 20% off)
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -385,10 +385,10 @@ Framework introduced in v2.1 connecting non-zero torsion on K₇ to RG flow. Key
 ### Scale Bridge (v2.1)
 Mathematical infrastructure linking dimensionless to dimensional observables: Λ_GIFT = 21×e⁸×248/(7×π⁴) ≈ 1.63×10⁶.
 
-### Lean 4 (v3.2)
+### Lean 4 (v3.3)
 Theorem prover used for formal verification of GIFT exact relations. The [gift-framework/core](https://github.com/gift-framework/core) repository contains 185 certified relations including E₈ root system, G₂ cross product properties, Fibonacci/Lucas embeddings, Prime Atlas, and Monstrous Moonshine. Key theorem: `GIFT_framework_certified`.
 
 ---
 
-Last updated: v3.2.0 (2026-01-05)
+Last updated: v3.3.0 (2026-01-12)
 

--- a/docs/OBSERVABLE_CATALOG.md
+++ b/docs/OBSERVABLE_CATALOG.md
@@ -65,7 +65,7 @@ Each observable receives a **Structural Inevitability** classification based on 
 |---|------------|--------------|-------|------|------|---------|-------|
 | 9 | **m_s/m_d** | p₂²×Weyl | 20 | 20.0 | 0.00% | 14 | ROBUST |
 | 10 | **m_c/m_s** | (dim_E₈-p₂)/b₂ | 246/21=11.71 | 11.7 | 0.12% | 5 | SUPPORTED |
-| 11 | **m_b/m_t** | 1/χ(K₇) | 1/42=0.0238 | 0.024 | 0.79% | 21 | CANONICAL |
+| 11 | **m_b/m_t** | 1/(2b₂) | 1/42=0.0238 | 0.024 | 0.79% | 21 | CANONICAL |
 | 12 | **m_u/m_d** | (1+dim_E₆)/PSL₂₇ | 79/168=0.470 | 0.47 | 0.05% | 1 | SINGULAR |
 
 ### 2.5 Neutrino/PMNS Sector (4)
@@ -126,7 +126,7 @@ Each observable receives a **Structural Inevitability** classification based on 
 | 30 | **Ω_b/Ω_m** | (dim_F₄-α_sum)/dim_E₈ | 39/248=0.157 | 0.157 | 0.16% | 7 | SUPPORTED |
 | 31 | **Ω_Λ/Ω_m** | (det_g_den-dim_K₇)/D_bulk | 25/11=2.27 | 2.27 | 0.12% | 6 | SUPPORTED |
 | 32 | **h (Hubble)** | (PSL₂₇-1)/dim_E₈ | 167/248=0.673 | 0.674 | 0.09% | 3 | DERIVED |
-| 33 | **σ₈** | (p₂+det_g_den)/χ(K₇) | 34/42=0.810 | 0.811 | 0.18% | 4 | DERIVED |
+| 33 | **σ₈** | (p₂+det_g_den)/(2b₂) | 34/42=0.810 | 0.811 | 0.18% | 4 | DERIVED |
 
 ---
 
@@ -150,7 +150,7 @@ Each observable receives a **Structural Inevitability** classification based on 
 | 40 | **b₂(K₇)** | 21 | Second Betti (gauge moduli) | 3+ | DERIVED |
 | 41 | **b₃(K₇)** | 77 | Third Betti (matter modes) | 3+ | DERIVED |
 | 42 | **H*** | 99 | b₂+b₃+1 (total cohomology) | 5+ | SUPPORTED |
-| 43 | **χ(K₇)** | 42 | Euler characteristic | 3+ | DERIVED |
+| 43 | **2b₂** | 42 | Structural invariant (note: χ(K₇)=0) | 3+ | DERIVED |
 
 ### 4.3 Exceptional Algebras (4)
 
@@ -231,7 +231,7 @@ b₂      = N_gen × dim(K₇)        = 3 × 7   = 21
 b₃ + dim(G₂) = dim(K₇) × α_sum   = 7 × 13  = 91
 α_sum   = rank(E₈) + Weyl        = 8 + 5   = 13
 D_bulk  = rank(E₈) + N_gen       = 8 + 3   = 11
-χ(K₇)   = p₂ × b₂                = 2 × 21  = 42
+2b₂     = p₂ × b₂                = 2 × 21  = 42
 H*      = b₂ + b₃ + 1            = 21+77+1 = 99
 ```
 
@@ -248,7 +248,7 @@ PSL(2,7) = 7 × 6 × 4             (Fano)    = 168
 
 | mod 7 | Constants |
 |-------|-----------|
-| **0** | dim_K₇, dim_G₂, b₂, b₃, fund_E₇, PSL₂₇, χ(K₇) |
+| **0** | dim_K₇, dim_G₂, b₂, b₃, fund_E₇, PSL₂₇, 2b₂ |
 | **1** | H*, rank_E₈, dim_E₆ |
 | **2** | p₂, det_g_num |
 | **3** | N_gen, dim_E₈ |

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # GIFT Framework - Documentation
 
-Supporting documentation for the GIFT Framework v3.2.
+Supporting documentation for the GIFT Framework v3.3.
 
 ## Contents
 
@@ -22,10 +22,10 @@ Static visualizations are available in the [`figures/`](figures/) directory:
 
 ## Main Documentation
 
-- [Main Paper](../publications/markdown/GIFT_v3.2_main.md) - Complete theoretical framework
-- [S1: Foundations](../publications/markdown/GIFT_v3.2_S1_foundations.md) - E₈, G₂, K₇ mathematical construction
-- [S2: Derivations](../publications/markdown/GIFT_v3.2_S2_derivations.md) - 18 dimensionless derivations
-- [S3: Dynamics](../publications/markdown/GIFT_v3.2_S3_dynamics.md) - RG flow, torsional dynamics
+- [Main Paper](../publications/markdown/GIFT_v3.3_main.md) - Complete theoretical framework
+- [S1: Foundations](../publications/markdown/GIFT_v3.3_S1_foundations.md) - E₈, G₂, K₇ mathematical construction
+- [S2: Derivations](../publications/markdown/GIFT_v3.3_S2_derivations.md) - 33 dimensionless derivations
+- [S3: Dynamics](../publications/markdown/GIFT_v3.3_S3_dynamics.md) - RG flow, torsional dynamics
 - [Observables CSV](../publications/references/39_observables.csv) - Machine-readable data
 
 ## Exploratory References
@@ -41,4 +41,4 @@ Historical supplements (v2.3/v3.0 drafts) archived in [`legacy/`](legacy/).
 
 ---
 
-Part of GIFT Framework v3.2 - MIT License
+Part of GIFT Framework v3.3 - MIT License

--- a/publications/README.md
+++ b/publications/README.md
@@ -1,4 +1,4 @@
-# GIFT Framework v3.2 - Publications
+# GIFT Framework v3.3 - Publications
 
 [![Lean 4 Verified](https://img.shields.io/badge/Lean_4-Verified-blue)](https://github.com/gift-framework/core/tree/main/Lean)
 [![Coq Verified](https://img.shields.io/badge/Coq_8.18-Verified-orange)](https://github.com/gift-framework/core/tree/main/COQ)
@@ -11,11 +11,11 @@ Geometric Information Field Theory: Deriving Standard Model parameters from E₈
 
 ```
 publications/
-├── markdown/                    # Core documents (v3.2)
-│   ├── GIFT_v3.2_main.md         # Main paper
-│   ├── GIFT_v3.2_S1_foundations.md   # E₈, G₂, K₇ foundations
-│   ├── GIFT_v3.2_S2_derivations.md   # 18 dimensionless derivations
-│   └── GIFT_v3.2_S3_dynamics.md      # RG flow, torsional dynamics
+├── markdown/                    # Core documents (v3.3)
+│   ├── GIFT_v3.3_main.md         # Main paper
+│   ├── GIFT_v3.3_S1_foundations.md   # E₈, G₂, K₇ foundations
+│   ├── GIFT_v3.3_S2_derivations.md   # 33 dimensionless derivations
+│   └── GIFT_v3.3_S3_dynamics.md      # RG flow, torsional dynamics
 │
 ├── references/                  # Exploratory & reference docs
 │   ├── 39_observables.csv      # Machine-readable data
@@ -31,16 +31,16 @@ publications/
 
 ## Core Documents
 
-### [GIFT_v3.2_main.md](markdown/GIFT_v3.2_main.md)
+### [GIFT_v3.3_main.md](markdown/GIFT_v3.3_main.md)
 Complete theoretical framework - the main paper.
 
-### [GIFT_v3.2_S1_foundations.md](markdown/GIFT_v3.2_S1_foundations.md)
+### [GIFT_v3.3_S1_foundations.md](markdown/GIFT_v3.3_S1_foundations.md)
 Mathematical foundations: E₈ exceptional algebra, G₂ holonomy, K₇ manifold construction.
 
-### [GIFT_v3.2_S2_derivations.md](markdown/GIFT_v3.2_S2_derivations.md)
-All 18 dimensionless derivations with complete proofs.
+### [GIFT_v3.3_S2_derivations.md](markdown/GIFT_v3.3_S2_derivations.md)
+All 33 dimensionless derivations with complete proofs.
 
-### [GIFT_v3.2_S3_dynamics.md](markdown/GIFT_v3.2_S3_dynamics.md)
+### [GIFT_v3.3_S3_dynamics.md](markdown/GIFT_v3.3_S3_dynamics.md)
 RG flow, torsional dynamics, scale bridge.
 
 ---
@@ -60,17 +60,17 @@ RG flow, torsional dynamics, scale bridge.
 | 9 | m_s/m_d | 20 | **PROVEN** |
 | 10 | δ_CP | 197° | **PROVEN** |
 
-**Zero continuous adjustable parameters. Mean deviation 0.24% (PDG 2024).**
+**Zero continuous adjustable parameters. Mean deviation 0.21% (PDG 2024).**
 
 ---
 
-## Statistical Validation (v3.2)
+## Statistical Validation (v3.3)
 
-Comprehensive Monte Carlo validation across 54,327 configurations:
+Comprehensive Monte Carlo validation across 192,349 configurations:
 
 | Metric | Value |
 |--------|-------|
-| Configurations tested | 54,327 |
+| Configurations tested | 192,349 |
 | Better alternatives | 0 |
 | p-value | < 10⁻⁵ |
 | Significance | > 4σ |
@@ -92,7 +92,7 @@ See [validation_v32.py](../statistical_validation/validation_v32.py) for methodo
 
 ## Formal Verification
 
-**185 relations verified** in Lean 4 + Coq (core v3.2.0).
+**185 relations verified** in Lean 4 + Coq (core v3.3.0).
 
 See [gift-framework/core](https://github.com/gift-framework/core) for proofs.
 
@@ -104,5 +104,5 @@ Historical supplements (S1-S9 v2.3/v3.0) are archived in `../docs/legacy/`.
 
 ---
 
-**Version**: 3.2.0 (2026-01-05)
+**Version**: 3.3.0 (2026-01-12)
 **Repository**: https://github.com/gift-framework/GIFT

--- a/publications/references/NUMBER_THEORETIC_STRUCTURES.md
+++ b/publications/references/NUMBER_THEORETIC_STRUCTURES.md
@@ -402,5 +402,5 @@ These patterns should be viewed as:
 
 ---
 
-*GIFT Framework v3.2 - Exploratory Content*
+*GIFT Framework v3.3 - Exploratory Content*
 *Status: PATTERN RECOGNITION - Mathematical facts verified, physical meaning speculative*

--- a/publications/references/README.md
+++ b/publications/references/README.md
@@ -1,6 +1,6 @@
 # GIFT Reference Documents
 
-Exploratory and reference documents for the GIFT framework v3.2.
+Exploratory and reference documents for the GIFT framework v3.3.
 
 ---
 
@@ -50,11 +50,11 @@ Exploratory and reference documents for the GIFT framework v3.2.
 ## Core Documents
 
 For the main framework documents, see [`../markdown/`](../markdown/):
-- [GIFT_v3.2_main.md](../markdown/GIFT_v3.2_main.md) - Main paper
-- [GIFT_v3.2_S1_foundations.md](../markdown/GIFT_v3.2_S1_foundations.md) - Foundations
-- [GIFT_v3.2_S2_derivations.md](../markdown/GIFT_v3.2_S2_derivations.md) - Derivations
-- [GIFT_v3.2_S3_dynamics.md](../markdown/GIFT_v3.2_S3_dynamics.md) - Dynamics
+- [GIFT_v3.3_main.md](../markdown/GIFT_v3.3_main.md) - Main paper
+- [GIFT_v3.3_S1_foundations.md](../markdown/GIFT_v3.3_S1_foundations.md) - Foundations
+- [GIFT_v3.3_S2_derivations.md](../markdown/GIFT_v3.3_S2_derivations.md) - Derivations
+- [GIFT_v3.3_S3_dynamics.md](../markdown/GIFT_v3.3_S3_dynamics.md) - Dynamics
 
 ---
 
-*Part of GIFT Framework v3.2*
+*Part of GIFT Framework v3.3*

--- a/publications/references/SPECULATIVE_PHYSICS.md
+++ b/publications/references/SPECULATIVE_PHYSICS.md
@@ -470,5 +470,5 @@ If GIFT predictions hold with continued precision:
 
 ---
 
-*GIFT Framework v3.2 - Exploratory Content*
+*GIFT Framework v3.3 - Exploratory Content*
 *Status: EXPLORATORY/SPECULATIVE - Not part of core Zenodo publication*


### PR DESCRIPTION
Update version references and statistics across 18 files:

Version updates (v3.2 → v3.3):
- 33 observables (was 18)
- 0.21% mean deviation (was 0.24%)
- 192,349 configurations tested (was 54,327)
- p < 5×10⁻⁶, >4.5σ significance
- All file references: GIFT_v3.2_*.md → GIFT_v3.3_*.md

Notation fix (χ(K₇) → 2b₂):
- Corrected: χ(K₇) = 0 for odd-dimensional manifolds
- The constant 42 = 2b₂ is a structural invariant, not Euler characteristic
- Updated in OBSERVABLE_CATALOG, EXTENDED_OBSERVABLES, Selection Rules

Added CHANGELOG entry for v3.3.0 with all changes.