### PR TITLE
Sync research branch with gift-framework/core v3.3.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to the GIFT framework are documented in this file.
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.14] - 2026-01-29
+
+### Synchronization with gift-framework/core v3.3.14
+
+This release synchronizes documentation with the latest formal verification developments in [gift-framework/core](https://github.com/gift-framework/core).
+
+#### Changed
+
+**Major Updates**
+- Updated to core v3.3.14 (~330 certified relations, up from 185)
+- Removed all Coq references — Lean 4 is now the sole verification system (Coq archived)
+- Updated terminology to use academic standards (no internal jargon)
+
+**Core v3.3.8–v3.3.14 Highlights** (see [core CHANGELOG](https://github.com/gift-framework/core/blob/main/CHANGELOG.md) for details):
+- **v3.3.14**: Selection Principle (κ = π²/14), TCS building blocks (Quintic, CI(2,2,2)), refined spectral bounds
+- **v3.3.13**: Literature axioms (Langlais 2024, CGN 2024 spectral density formulas)
+- **v3.3.12**: TCS Spectral Bounds Model Theorem (λ₁ ~ 1/L²)
+- **v3.3.11**: Monster dimension via Coxeter numbers (196883 = (b₃−h_G₂)(b₃−h_E₇)(b₃−h_E₈))
+- **v3.3.10**: GIFT-Zeta correspondences, Monster-Zeta Moonshine
+- **v3.3.9**: Complete Spectral Theory module
+- **v3.3.8**: Yang-Mills Mass Gap module (λ₁ = 14/99)
+
+**Documentation Updates**
+- README.md, CITATION.md, STRUCTURE.md: Updated metrics and removed Coq badges
+- docs/*: Updated version references and Coq mentions
+- publications/README.md: Updated badge and metrics
+
+---
+
 ## [3.3.11] - 2026-01-25
 
 ### Complete Analytical Framework: Three Integers

--- a/CITATION.md
+++ b/CITATION.md
@@ -134,13 +134,13 @@ de La Fournière, Brieuc. "GIFT Framework v3.3: Geometric Information Field Theo
 ## Formal Verification
 
 ```bibtex
-@software{gift_core_v320,
-  title   = {GIFT Core: Formal Verification in Lean 4 + Coq},
+@software{gift_core_v3314,
+  title   = {GIFT Core: Formal Verification in Lean 4},
   author  = {de La Fournière, Brieuc},
   year    = {2026},
   url     = {https://github.com/gift-framework/core},
-  version = {3.3.7},
-  note    = {185 relations verified, 15 axioms, K₇ metric pipeline, Joyce existence theorem}
+  version = {3.3.14},
+  note    = {~330 relations verified, K₇ metric pipeline, Joyce existence theorem}
 }
 ```
 
@@ -159,10 +159,11 @@ de La Fournière, Brieuc. "GIFT Framework v3.3: Geometric Information Field Theo
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| 3.3.14 | 2026-01-28 | ~330 relations, Lean 4 only (Coq archived) |
 | 3.3.0 | 2026-01-05 | PDG 2024 values, 54,327-config Monte Carlo validation |
 | 3.1.0 | 2025-12-17 | Analytical G₂ metric, 185 certified relations |
 | 3.0.0 | 2025-12-09 | Major release: 165+ certified relations, Fibonacci/Monster/McKay |
-| 2.3.x | 2025-12 | Dual Lean 4 + Coq verification |
+| 2.3.x | 2025-12 | Dual Lean 4 + Coq verification (historical) |
 | 2.2.0 | 2025-11-27 | Zero-parameter paradigm |
 | 2.1.0 | 2025-11-22 | Torsional dynamics |
 | 2.0.0 | 2025-10-24 | Framework reorganization |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -187,7 +187,7 @@ for effective torsion that remain under investigation"
 
 | Status | Meaning |
 |--------|---------|
-| **PROVEN** | Formally verified in Lean 4 + Coq |
+| **PROVEN** | Formally verified in Lean 4 |
 | **TOPOLOGICAL** | Derived from topology, not fitted |
 | **THEORETICAL** | Proposed mechanism, not yet verified |
 | **SPECULATIVE** | Exploratory extension |
@@ -203,7 +203,7 @@ for effective torsion that remain under investigation"
 - Guides for different audiences
 
 ### gift-framework/core
-- Formal proofs (Lean 4 + Coq)
+- Formal proofs (Lean 4)
 - Python package `gift_core`
 - Blueprint documentation
 - CI/CD workflows

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Geometric Information Field Theory v3.3
 
 [![License](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
-[![Version](https://img.shields.io/badge/Version-3.3.7-green.svg)](CHANGELOG.md)
-[![Lean 4 + Coq](https://img.shields.io/badge/Formally_Verified-Lean_4_+_Coq-blue)](https://github.com/gift-framework/core)
+[![Version](https://img.shields.io/badge/Version-3.3.14-green.svg)](CHANGELOG.md)
+[![Lean 4](https://img.shields.io/badge/Formally_Verified-Lean_4-blue)](https://github.com/gift-framework/core)
 
 **Standard Model parameters from pure geometry** — E₈×E₈ on G₂-holonomy manifold K₇, zero adjustable parameters.
 
@@ -15,7 +15,7 @@
 | **Precision** | 0.21% mean deviation across 33 dimensionless predictions (PDG 2024) |
 | **Uniqueness** | #1 out of 192,349 configurations tested (>4.5σ significance) |
 | **Parameters** | Zero adjustable (all structurally determined) |
-| **Verified** | 185 relations proven in Lean 4 + Coq (15 axioms, core v3.3.7) |
+| **Verified** | ~330 relations proven in Lean 4 (core v3.3.14) |
 | **Exact results** | sin²θ_W = 3/13 · τ = 3472/891 · det(g) = 65/32 · Monster = 47×59×71 |
 
 **Dimensional reduction:** E₈×E₈ (496D) → AdS₄ × K₇ (11D) → Standard Model (4D)
@@ -26,7 +26,7 @@
 
 | Paper | Proofs | Video |
 |:-----:|:------:|:-----:|
-| [Main Paper](publications/markdown/GIFT_v3.3_main.md) | [Lean 4 + Coq](https://github.com/gift-framework/core) | [YouTube (8 min)](https://www.youtube.com/watch?v=6DVck30Q6XM) |
+| [Main Paper](publications/markdown/GIFT_v3.3_main.md) | [Lean 4](https://github.com/gift-framework/core) | [YouTube (8 min)](https://www.youtube.com/watch?v=6DVck30Q6XM) |
 
 ---
 
@@ -73,7 +73,7 @@
 | Cosmology | 3 | 0.07% | n_s = ζ(11)/ζ(5) (0.004%) |
 | Structural | 4 | exact | N_gen = 3, τ = 3472/891 |
 
-### Exact Relations (Lean 4 + Coq Verified)
+### Exact Relations (Lean 4 Verified)
 
 | Relation | Value | Topological Origin |
 |----------|:-----:|-------------------|
@@ -200,7 +200,7 @@ Their appearance suggests structural rather than coincidental relationships.
 
 | Repository | Description |
 |------------|-------------|
-| [gift-framework/core](https://github.com/gift-framework/core) | Formal verification (Lean 4 + Coq), K₇ metric pipeline |
+| [gift-framework/core](https://github.com/gift-framework/core) | Formal verification (Lean 4), K₇ metric pipeline |
 
 ---
 
@@ -227,7 +227,7 @@ Their appearance suggests structural rather than coincidental relationships.
   author  = {de La Fournière, Brieuc},
   year    = {2026},
   url     = {https://github.com/gift-framework/GIFT},
-  version = {3.3.7}
+  version = {3.3.14}
 }
 ```
 

--- a/STRUCTURE.md
+++ b/STRUCTURE.md
@@ -96,12 +96,12 @@ GIFT/
 
 | Repository | Content |
 |------------|---------|
-| [gift-framework/core](https://github.com/gift-framework/core) | Formal proofs (Lean 4 + Coq), K₇ metric pipeline, giftpy |
+| [gift-framework/core](https://github.com/gift-framework/core) | Formal proofs (Lean 4), K₇ metric pipeline, giftpy |
 
 ## Version
 
-**Current**: v3.3.7 (2026-01-16)
-**Relations**: 185 certified, 15 axioms (core v3.3.7)
+**Current**: v3.3.14 (2026-01-28)
+**Relations**: ~330 certified (core v3.3.14)
 **Predictions**: 33 dimensionless (**0.21% mean deviation, PDG 2024**)
 **Monte Carlo**: 192,349 configurations tested, 0 better than GIFT
 **Key Result**: Analytical G₂ metric with T = 0 exactly

--- a/docs/EXPERIMENTAL_VALIDATION.md
+++ b/docs/EXPERIMENTAL_VALIDATION.md
@@ -10,7 +10,7 @@ The GIFT framework v3.3 makes 33 dimensionless predictions with mean experimenta
 - Planned experiments and timelines
 - Criteria for validation or falsification
 
-**Last updated**: 2026-01-16 (v3.3.7)
+**Last updated**: 2026-01-28 (v3.3.14)
 
 ## Current Experimental Status Summary
 
@@ -169,7 +169,7 @@ All elements predicted with mean deviation 0.11%. Highlights:
 | v2.0 | 34 | 3 | 0.13% | Rigorous proofs, complete neutrino sector, parameter reduction |
 | v2.1 | 46 | 3 | 0.13% | Torsional dynamics, scale bridge, 9 dimensional observables |
 | v2.2 | 39 | 0 | 0.197% | Zero-parameter paradigm, 13 proven relations, consolidated catalog |
-| v2.3 | 39 | 0 | 0.197% | Dual formal verification (Lean 4 + Coq), unified CI pipeline |
+| v2.3 | 39 | 0 | 0.197% | Dual formal verification (Lean 4 + Coq), unified CI pipeline (historical) |
 | v2.3.1 | 39 | 0 | 0.197% | 25 proven relations (12 topological extension), giftpy v1.1.0 |
 | v2.3.3 | 39 | 0 | 0.197% | 39 proven relations (+ 10 Yukawa + 4 irrational), giftpy v1.4.0 |
 | v2.3.4 | 39 | 0 | 0.197% | 54 proven relations (+ 5 exceptional + 6 base decomp + 4 extended), giftpy v1.5.0 |
@@ -351,7 +351,7 @@ No sector shows systematic problems. All perform well.
 - Genuine predictive power
 - Complete elimination of free parameters
 - All quantities structurally determined
-- 185 relations formally verified in Lean 4 + Coq
+- ~330 relations formally verified in Lean 4
 
 **Other unification attempts**:
 - SU(5) GUT: Incorrect sin²θ_W prediction (~0.20 vs 0.23)

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -351,7 +351,7 @@ Depends on background:
 
 ### Is there a paper I can cite?
 
-Current version (v3.3.7) is available on GitHub. Citation format in `CITATION.md`:
+Current version (v3.3.14) is available on GitHub. Citation format in `CITATION.md`:
 
 ```bibtex
 @software{gift_framework_v33,

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -386,9 +386,9 @@ Framework introduced in v2.1 connecting non-zero torsion on K₇ to RG flow. Key
 Mathematical infrastructure linking dimensionless to dimensional observables: Λ_GIFT = 21×e⁸×248/(7×π⁴) ≈ 1.63×10⁶.
 
 ### Lean 4 (v3.3)
-Theorem prover used for formal verification of GIFT exact relations. The [gift-framework/core](https://github.com/gift-framework/core) repository contains 185 certified relations including E₈ root system, G₂ cross product properties, Fibonacci/Lucas embeddings, Prime Atlas, and Monstrous Moonshine. Key theorem: `GIFT_framework_certified`.
+Theorem prover used for formal verification of GIFT exact relations. The [gift-framework/core](https://github.com/gift-framework/core) repository contains ~330 certified relations including E₈ root system, G₂ cross product properties, Fibonacci/Lucas embeddings, Prime Atlas, Monstrous Moonshine, Spectral Theory, and GIFT-Zeta correspondences. Key theorem: `GIFT_framework_certified`.
 
 ---
 
-Last updated: v3.3.7 (2026-01-16)
+Last updated: v3.3.14 (2026-01-28)
 

--- a/publications/README.md
+++ b/publications/README.md
@@ -1,7 +1,6 @@
 # GIFT Framework v3.3 - Publications
 
 [![Lean 4 Verified](https://img.shields.io/badge/Lean_4-Verified-blue)](https://github.com/gift-framework/core/tree/main/Lean)
-[![Coq Verified](https://img.shields.io/badge/Coq_8.18-Verified-orange)](https://github.com/gift-framework/core/tree/main/COQ)
 
 Geometric Information Field Theory: Deriving Standard Model parameters from E₈×E₈ topology.
 
@@ -92,7 +91,7 @@ See [validation_v32.py](../statistical_validation/validation_v32.py) for methodo
 
 ## Formal Verification
 
-**185 relations verified** in Lean 4 + Coq (15 axioms, core v3.3.7).
+**~330 relations verified** in Lean 4 (core v3.3.14).
 
 See [gift-framework/core](https://github.com/gift-framework/core) for proofs.
 
@@ -104,5 +103,5 @@ Historical supplements (S1-S9 v2.3/v3.0) are archived in `../docs/legacy/`.
 
 ---
 
-**Version**: 3.3.7 (2026-01-16)
+**Version**: 3.3.14 (2026-01-28)
 **Repository**: https://github.com/gift-framework/GIFT

--- a/publications/markdown/GIFT_v3.3_S1_foundations.md
+++ b/publications/markdown/GIFT_v3.3_S1_foundations.md
@@ -6,7 +6,7 @@
 
 *Complete mathematical foundations for GIFT, presenting E8 architecture and K7 manifold construction.*
 
-**Lean Verification**: 185 relations, 15 axioms (core v3.3.7)
+**Lean Verification**: ~330 relations (core v3.3.14)
 
 ---
 
@@ -121,7 +121,7 @@ $$\frac{1}{2}(\pm 1, \pm 1, \pm 1, \pm 1, \pm 1, \pm 1, \pm 1, \pm 1)$$
 
 **Verification**: 112 + 128 = 240 roots, all length √2.
 
-**Lean Status (v3.3.7)**: E₈ Root System **12/12 COMPLETE** — All theorems proven:
+**Lean Status (v3.3.14)**: E₈ Root System **12/12 COMPLETE** — All theorems proven:
 - `D8_roots_card` = 112, `HalfInt_roots_card` = 128
 - `E8_roots_card` = 240, `E8_roots_decomposition`
 - `E8_inner_integral`, `E8_norm_sq_even`, `E8_sub_closed`
@@ -336,7 +336,7 @@ This anchors τ to topological and algebraic invariants, establishing it as a ge
 | rank(G₂) | 2 | Lie rank |
 | Definition | Aut(O) | Octonion automorphisms |
 
-**Lean Status (v3.3.7)**: G₂ Cross Product **9/11** proven:
+**Lean Status (v3.3.14)**: G₂ Cross Product **9/11** proven:
 - `epsilon_antisymm`, `epsilon_diag`, `cross_apply` ✓
 - `G2_cross_bilinear`, `G2_cross_antisymm`, `cross_self` ✓
 - `G2_cross_norm` (Lagrange identity ‖u×v‖² = ‖u‖²‖v‖² − ⟨u,v⟩²) ✓

--- a/publications/markdown/GIFT_v3.3_main.md
+++ b/publications/markdown/GIFT_v3.3_main.md
@@ -891,7 +891,7 @@ Unlike many approaches to fundamental physics, GIFT makes sharp, testable predic
 
 ### 14.4 Mathematical Rigor
 
-The topological foundations rest on established mathematics. The TCS construction follows Joyce, Kovalev, and collaborators. The index theorem derivation of N_gen = 3 is standard. 185 relations have been verified in Lean 4 (core v3.3.7, 15 axioms remaining), providing machine-checked confirmation of algebraic claims. The E₈ root system is fully proven (12/12 theorems), including `E8_basis_generates` now a theorem rather than axiom.
+The topological foundations rest on established mathematics. The TCS construction follows Joyce, Kovalev, and collaborators. The index theorem derivation of N_gen = 3 is standard. ~330 relations have been verified in Lean 4 (core v3.3.14), providing machine-checked confirmation of algebraic claims. The E₈ root system is fully proven (12/12 theorems), including `E8_basis_generates` now a theorem rather than axiom.
 
 ---
 


### PR DESCRIPTION
Major updates:
- Update relation count: 185 → ~330 certified relations
- Remove Coq references (archived in core, Lean 4 sole verification system)
- Update version references: v3.3.7 → v3.3.14

Changes by file category:
- Root docs (README, CHANGELOG, CITATION, STRUCTURE, CLAUDE.md)
- docs/* (FAQ, GLOSSARY, EXPERIMENTAL_VALIDATION)
- publications/* (README, S1 foundations, main paper)

New in core v3.3.8-v3.3.14:
- Selection Principle (κ = π²/14)
- TCS Spectral Bounds
- Monster-Coxeter formula
- GIFT-Zeta correspondences
- Literature axioms (Langlais 2024, CGN 2024)

https://claude.ai/code/session_01EQGFfDk2mbnGKUwa1YXpXY