### PR TITLE
fix(ci): fix cross-repo parser false positives, add VERIFIED status, …

### DIFF
--- a/.github/scripts/docs_linter.py
+++ b/.github/scripts/docs_linter.py
@@ -58,6 +58,9 @@ VALID_STATUSES = {
     'CONSISTENT',
     'COMPLETE',
     'EXPERIMENTAL',
+    'VERIFIED',
+    'VERIFIED (Lean 4)',
+    'STRUCTURAL',
 }
 
 # Em dash (prohibited)

--- a/.github/workflows/cross-repo-consistency.yml
+++ b/.github/workflows/cross-repo-consistency.yml
@@ -8,6 +8,10 @@ on:
       - '.github/scripts/cross_repo_check.py'
   pull_request:
     branches: [main]
+    paths:
+      - 'publications/papers/markdown/*.md'
+      - '.github/scripts/cross_repo_check.py'
+      - '.github/workflows/cross-repo-consistency.yml'
   # Triggered by repository_dispatch from gift-framework/core
   repository_dispatch:
     types: [core-updated]

--- a/.github/workflows/docs-linter.yml
+++ b/.github/workflows/docs-linter.yml
@@ -10,6 +10,8 @@ on:
     paths:
       - 'publications/papers/markdown/*.md'
       - 'docs/*.md'
+      - '.github/scripts/docs_linter.py'
+      - '.github/scripts/fix_em_dashes.py'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/observable-calculator.yml
+++ b/.github/workflows/observable-calculator.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'publications/papers/markdown/*.md'
       - 'publications/validation/*.py'
+      - '.github/scripts/observable_calculator.py'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
…tighten PR triggers

- cross_repo_check.py: Replace greedy table regex with targeted per-constant patterns to eliminate false positives (DIM_G2=16384, WEYL=243 from Weyl decomposition table). Fix Lean parser to only match simple literal assignments. Add resolution of computed expressions (H_STAR = B2 + B3 + 1). Normalize Lean constant keys to uppercase for uniform comparison.
- docs_linter.py: Add VERIFIED, VERIFIED (Lean 4), and STRUCTURAL to valid status classifications (reduces warnings from 48 to 34).
- Workflows: Add CI script paths to PR triggers so script changes properly trigger validation.

Validated against cloned gift-framework/core: 15 matches, 0 mismatches.

https://claude.ai/code/session_011PUHntt84ob9Z5i9h1xH35